### PR TITLE
Don't use hardcoded Desktop path

### DIFF
--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -1610,9 +1610,8 @@ function Worker {
     clear
     $columns = 4096
 
-    $user          = [Environment]::UserName
     $workDirPrefix = "msdbg." + $env:computername
-    $baseDir       = "C:\Users\$user\Desktop\"
+    $baseDir       = [Environment]::GetFolderPath("Desktop")
     $workDir       = "$baseDir" + "$workDirPrefix"
 
     EnvDestroy        -OutDir $workDir

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -1611,7 +1611,7 @@ function Worker {
     $columns = 4096
 
     $workDirPrefix = "msdbg." + $env:computername
-    $baseDir       = [Environment]::GetFolderPath("Desktop")
+    $baseDir       = [Environment]::GetFolderPath("Desktop") + "\"
     $workDir       = "$baseDir" + "$workDirPrefix"
 
     EnvDestroy        -OutDir $workDir


### PR DESCRIPTION
Fixes the script not working correctly if the Desktop folder is in a nonstandard location (such as a different drive letter) or the user's account folder has the form "username.domain", which can be created by default in certain scenarios.