### PR TITLE
Bug 75108 NC Service Template must trim client and management security groups

### DIFF
--- a/VMM/Templates/NC/NCSetup.cr/InstallNetworkController-AllNodes.ps1
+++ b/VMM/Templates/NC/NCSetup.cr/InstallNetworkController-AllNodes.ps1
@@ -10,7 +10,35 @@ $ErrorCode_Success = 0;
 $ErrorCode_Failed = 1;
 
 try
-{        
+{  
+    #-----------------------------------------------------------
+    # Trim Leading and Trailing Spaces of user input parameters
+    #-----------------------------------------------------------
+     if(-not [String]::IsNullOrEmpty($mgmtSecurityGroupName))
+	 {
+		$mgmtSecurityGroupName = $mgmtSecurityGroupName.Trim()
+     }
+	 if(-not [String]::IsNullOrEmpty($clientSecurityGroupName))
+	 {
+		$clientSecurityGroupName = $clientSecurityGroupName.Trim();
+     }
+     if(-not [String]::IsNullOrEmpty($diagnosticLogShare))
+	 {
+		$diagnosticLogShare = $diagnosticLogShare.Trim();
+     }
+	 if(-not [String]::IsNullOrEmpty($diagnosticLogShareUsername))
+	 {
+		$diagnosticLogShareUsername = $diagnosticLogShareUsername.Trim();
+     }
+	 if(-not [String]::IsNullOrEmpty($mgmtDomainAccountUserName))
+	 {
+		$mgmtDomainAccountUserName = $mgmtDomainAccountUserName.Trim();
+     }
+	 if(-not [String]::IsNullOrEmpty($restEndPoint))
+	 {
+		$restEndPoint = $restEndPoint.Trim();
+     }
+         
     # Start the network controller cmdlet log collection
     StartNetworkControllerLogging
     

--- a/VMM/Templates/NC/NCSetup.cr/LogParameters.ps1
+++ b/VMM/Templates/NC/NCSetup.cr/LogParameters.ps1
@@ -15,7 +15,35 @@ $ErrorCode_Success = 0
 $ErrorCode_Failed = 1
 
 try 
-{    
+{ 
+    #-----------------------------------------------------------
+    # Trim Leading and Trailing Spaces of user input parameters
+    #-----------------------------------------------------------
+     if(-not [String]::IsNullOrEmpty($mgmtSecurityGroupName))
+	 {
+		$mgmtSecurityGroupName = $mgmtSecurityGroupName.Trim()
+     }
+	 if(-not [String]::IsNullOrEmpty($clientSecurityGroupName))
+	 {
+		$clientSecurityGroupName = $clientSecurityGroupName.Trim();
+     }
+     if(-not [String]::IsNullOrEmpty($diagnosticLogShare))
+	 {
+		$diagnosticLogShare = $diagnosticLogShare.Trim();
+     }
+	 if(-not [String]::IsNullOrEmpty($diagnosticLogShareUsername))
+	 {
+		$diagnosticLogShareUsername = $diagnosticLogShareUsername.Trim();
+     }
+	 if(-not [String]::IsNullOrEmpty($mgmtDomainAccountUserName))
+	 {
+		$mgmtDomainAccountUserName = $mgmtDomainAccountUserName.Trim();
+     }
+	 if(-not [String]::IsNullOrEmpty($restEndPoint))
+	 {
+		$restEndPoint = $restEndPoint.Trim();
+     }
+    
     Log "Network Controller has been installed with the following parameters:"
     Log "    serviceVMComputerNames: $serviceVMComputerNames"
     Log "    mgmtSecurityGroupName: $mgmtSecurityGroupName"

--- a/VMM/Templates/NC/NCSetup.cr/PrepareNodeForNetworkController.ps1
+++ b/VMM/Templates/NC/NCSetup.cr/PrepareNodeForNetworkController.ps1
@@ -11,6 +11,17 @@ $ErrorCode_Failed = 1
 
 try
 {
+    #-----------------------------------------------------------
+    # Trim Leading and Trailing Spaces of user input parameters
+    #-----------------------------------------------------------
+	 if(-not [String]::IsNullOrEmpty($mgmtDomainAccountUserName))
+	 {
+		$mgmtDomainAccountUserName = $mgmtDomainAccountUserName.Trim();
+     }
+	 if(-not [String]::IsNullOrEmpty($restEndPoint))
+	 {
+		$restEndPoint = $restEndPoint.Trim();
+     }
     #------------------------------------------
     # Disable IPv6, as is not supported by Network Controller
     #------------------------------------------

--- a/VMM/Templates/NC/NCSetup.cr/ScaleInNode.ps1
+++ b/VMM/Templates/NC/NCSetup.cr/ScaleInNode.ps1
@@ -11,6 +11,14 @@ $ErrorCode_Failed = 1;
 
 try
 {
+    #-----------------------------------------------------------
+    # Trim Leading and Trailing Spaces of user input parameters
+    #-----------------------------------------------------------
+	 if(-not [String]::IsNullOrEmpty($mgmtDomainAccountUserName))
+	 {
+		$mgmtDomainAccountUserName = $mgmtDomainAccountUserName.Trim();
+     }
+ 
     #------------------------------------------
     # Get network controller node info
     #------------------------------------------

--- a/VMM/Templates/NC/NCSetup.cr/ScaleOutNode.ps1
+++ b/VMM/Templates/NC/NCSetup.cr/ScaleOutNode.ps1
@@ -11,6 +11,18 @@ $ErrorCode_Failed = 1;
 
 try
 {
+    #-----------------------------------------------------------
+    # Trim Leading and Trailing Spaces of user input parameters
+    #-----------------------------------------------------------
+	 if(-not [String]::IsNullOrEmpty($mgmtDomainAccountUserName))
+	 {
+		$mgmtDomainAccountUserName = $mgmtDomainAccountUserName.Trim();
+     }
+	 if(-not [String]::IsNullOrEmpty($restEndPoint))
+	 {
+		$restEndPoint = $restEndPoint.Trim();
+     }
+ 
     #------------------------------------------
     # Check for standalone deployment
     #------------------------------------------

--- a/VMM/Templates/NC/NCSetup.cr/UpdateNetworkController.ps1
+++ b/VMM/Templates/NC/NCSetup.cr/UpdateNetworkController.ps1
@@ -10,7 +10,35 @@ $ErrorCode_Success = 0
 $ErrorCode_Failed = 1
 
 try 
-{    
+{ 
+    #-----------------------------------------------------------
+    # Trim Leading and Trailing Spaces of user input parameters
+    #-----------------------------------------------------------
+     if(-not [String]::IsNullOrEmpty($mgmtSecurityGroupName))
+	 {
+		$mgmtSecurityGroupName = $mgmtSecurityGroupName.Trim()
+     }
+	 if(-not [String]::IsNullOrEmpty($clientSecurityGroupName))
+	 {
+		$clientSecurityGroupName = $clientSecurityGroupName.Trim();
+     }
+     if(-not [String]::IsNullOrEmpty($diagnosticLogShare))
+	 {
+		$diagnosticLogShare = $diagnosticLogShare.Trim();
+     }
+	 if(-not [String]::IsNullOrEmpty($diagnosticLogShareUsername))
+	 {
+		$diagnosticLogShareUsername = $diagnosticLogShareUsername.Trim();
+     }
+	 if(-not [String]::IsNullOrEmpty($mgmtDomainAccountUserName))
+	 {
+		$mgmtDomainAccountUserName = $mgmtDomainAccountUserName.Trim();
+     }
+	 if(-not [String]::IsNullOrEmpty($restEndPoint))
+	 {
+		$restEndPoint = $restEndPoint.Trim();
+     }
+    
     #------------------------------------------
     # Get existing configuration
     #------------------------------------------

--- a/VMM/Templates/NC/NCSetup.cr/ValidateParameters.ps1
+++ b/VMM/Templates/NC/NCSetup.cr/ValidateParameters.ps1
@@ -10,7 +10,28 @@ $ErrorCode_Success = 0
 $ErrorCode_Failed = 1
 
 try 
-{    
+{
+    #-----------------------------------------------------------
+    # Trim Leading and Trailing Spaces of user input parameters
+    #-----------------------------------------------------------
+     if(-not [String]::IsNullOrEmpty($mgmtSecurityGroupName))
+	 {
+		$mgmtSecurityGroupName = $mgmtSecurityGroupName.Trim()
+     }
+	 if(-not [String]::IsNullOrEmpty($clientSecurityGroupName))
+	 {
+		$clientSecurityGroupName = $clientSecurityGroupName.Trim();
+     }
+	 if(-not [String]::IsNullOrEmpty($mgmtDomainAccountUserName))
+	 {
+		$mgmtDomainAccountUserName = $mgmtDomainAccountUserName.Trim();
+     }
+	 if(-not [String]::IsNullOrEmpty($restEndPoint))
+	 {
+		$restEndPoint = $restEndPoint.Trim();
+     }
+ 
+    
     #------------------------------------------
     # Validate Management Security Group Parameter
     #------------------------------------------


### PR DESCRIPTION
This pull request fixes the Bug 75108. There are some issues where the
input parameter contains heading or trailling spaces. hence the scipts
are updated to trim the heading and trailing spaces in input parameters,
only the text input parameters are modified, passoword, Domain name etc
are consumed as it is.