### PR TITLE
Add Chelsio submitted improvements & other changes

### DIFF
--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -77,17 +77,6 @@ function ExecCommandPrivate {
     Invoke-Expression $Command | Out-File -Encoding ascii -Append $Output
 } #ExecCommandPrivate()
 
-function ExecCommandTrusted {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Command,
-        [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Output
-    )
-
-    Write-Host -ForegroundColor Cyan "$Command"
-    ExecCommandPrivate -Command ($Command) -Output $Output
-} # ExecCommandTrusted()
-
 enum CommandStatus {
     NotTested    # Indicates problem with TestCommand
     Unavailable  # [Part of] the command doesn't exist
@@ -142,22 +131,27 @@ function ExecCommand {
     [CmdletBinding()]
     Param(
         [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Command,
-        [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Output
+        [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Output,
+        [parameter(Mandatory=$false)] [Switch] $Trusted
     )
 
-    # Use temp output to reflect the failed command, otherwise execute the command.
-    $out = $Output
-
-    $result = TestCommand -Command ($cmd)
-    if ($result -eq [CommandStatus]::Succeeded) {
-        Write-Host -ForegroundColor Green "$Command"
-        ExecCommandPrivate -Command ($Command) -Output $out
+    if ($Trusted) {
+        # Skip command validation
+        Write-Host -ForegroundColor Cyan "$Command"
+        ExecCommandPrivate -Command $Command -Output $Output
     } else {
-        Write-Warning "[Command $result] $Command"
+        $result = TestCommand -Command $Command
 
-        Write-Output "$Command" | Out-File -Encoding ascii -Append $out
-        Write-Output "[Command $result]" | Out-File -Encoding ascii -Append $out
-        Write-Output "`n`n" | Out-File -Encoding ascii -Append $out
+        if ($result -eq [CommandStatus]::Succeeded) {
+            Write-Host -ForegroundColor Green "$Command"
+            ExecCommandPrivate -Command $Command -Output $Output
+        } else {
+            Write-Warning "[Command $result] $Command"
+
+            Write-Output "$Command" | Out-File -Encoding ascii -Append $Output
+            Write-Output "[Command $result]" | Out-File -Encoding ascii -Append $Output
+            Write-Output "`n`n" | Out-File -Encoding ascii -Append $Output
+        }
     }
 } # ExecCommand()
 
@@ -321,7 +315,7 @@ function NetIpWorker {
                         "Get-NetTCPConnection | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetTCPConnection | Get-Member"
     ForEach($cmd in $cmds) {
-        ExecCommandTrusted -Command ($cmd) -Output $out
+        ExecCommand -Trusted -Command ($cmd) -Output $out
     }
 
     $file = "Get-NetTcpSetting.txt"
@@ -330,7 +324,7 @@ function NetIpWorker {
                         "Get-NetTcpSetting  | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetTcpSetting  | Get-Member"
     ForEach($cmd in $cmds) {
-        ExecCommandTrusted -Command ($cmd) -Output $out
+        ExecCommand -Trusted -Command ($cmd) -Output $out
     }
 
     $file = "Get-NetTransportFilter.txt"
@@ -1484,7 +1478,7 @@ function NetSetupDetail {
     ForEach($cmd in $cmds) {
         if (Test-Path $cmd) {
             $tcmd = "Copy-Item $cmd $dir -recurse -verbose 4>&1"
-            ExecCommandTrusted -Command ($tcmd) -Output $out
+            ExecCommand -Trusted -Command ($tcmd) -Output $out
         }
     }   
 } # NetSetupDetail()
@@ -1566,9 +1560,9 @@ function ServicesDrivers {
     
     $file = "Get-WindowsDriver.txt"
     $out  = (Join-Path -Path $dir -ChildPath $file)
-    [String []] $cmds = "Get-WindowsDriver -Online -All"
+    [String []] $cmds = "Get-WindowsDriver -Online -All" # very slow, -Trusted to skip validation
     ForEach($cmd in $cmds) {
-        ExecCommandTrusted -Command $cmd -Output $out
+        ExecCommand -Trusted -Command $cmd -Output $out
     }
 
     $file = "Get-WindowsEdition.txt"
@@ -1614,7 +1608,7 @@ function NetshTrace {
                         "Stop-NetEventSession   NetRundown",
                         "Remove-NetEventSession NetRundown"
     ForEach($cmd in $cmds) {
-        ExecCommandTrusted -Command $cmd -Output $out
+        ExecCommand -Trusted -Command $cmd -Output $out
     }
 
     #
@@ -1652,7 +1646,7 @@ function NetshTrace {
                         "netsh trace show providers",
                         "netsh trace  diagnose scenario=NetworkSnapshot mode=Telemetry saveSessionTrace=yes report=yes ReportFile=$dir\Snapshot.cab"
     ForEach($cmd in $cmds) {
-        ExecCommandTrusted -Command $cmd -Output $out
+        ExecCommand -Trusted -Command $cmd -Output $out
     }
 } # NetshTrace()
 
@@ -1718,7 +1712,7 @@ function HwErrorReport {
     $out  = (Join-Path -Path $OutDir -ChildPath $file)
     [String []] $cmds = "copy-item $env:ProgramData\Microsoft\Windows\WER $outdir -recurse -verbose 4>&1"
     ForEach($cmd in $cmds) {
-        ExecCommandTrusted -Command ($cmd) -Output $out
+        ExecCommand -Trusted -Command ($cmd) -Output $out
     }
 } # HwErrorReport()
 
@@ -1732,7 +1726,7 @@ function LogsReport {
     $out  = (Join-Path -Path $OutDir -ChildPath $file)
     [String []] $cmds = "copy-item C:\Windows\System32\winevt $outdir -recurse -verbose 4>&1"
     ForEach($cmd in $cmds) {
-        ExecCommandTrusted -Command ($cmd) -Output $out
+        ExecCommand -Trusted -Command ($cmd) -Output $out
     }
 } # LogsReport()
 

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -55,13 +55,13 @@ function ExecCommandText {
         [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Output
     )
 
-    # Mirror Prompt info
-    $prompt = $env:username + " @ " + $env:computername + ":"
-    Write-Output $prompt | out-file -Encoding ascii -Append $Output
+    # Mirror command execution context
+    $context = "$env:USERNAME @ $env:COMPUTERNAME:"
+    Write-Output $context | Out-File -Encoding ascii -Append $Output
 
-    # Mirror Command to execute
-    $cmdMirror = "PS " + (Convert-Path .) + "> " + $Command
-    Write-Output $cmdMirror | out-file -Encoding ascii -Append $Output
+    # Mirror command to execute
+    $cmdMirror = "$(prompt)$Command"
+    Write-Output $cmdMirror | Out-File -Encoding ascii -Append $Output
 } # ExecCommandText()
 
 function ExecCommandPrivate {
@@ -1365,16 +1365,16 @@ function NetworkSummary {
 
     $file = "Get-NetAdapter.txt"
     $out  = (Join-Path -Path $OutDir -ChildPath $file)
-        [String []] $cmds = "Get-NetAdapter -includeHidden | Sort-Object InterfaceDescription | Format-Table -AutoSize",
-                            "Get-NetAdapter -includeHidden | Format-Table -Property * -AutoSize | Sort-Object InterfaceDescription | Out-String -Width $columns"
+        [String []] $cmds = "Get-NetAdapter -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -AutoSize",
+                            "Get-NetAdapter -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ForEach($cmd in $cmds) {
         ExecCommand -Command $cmd -Output $out
     }
 
     $file = "Get-NetAdapterStatistics.txt"
     $out  = (Join-Path -Path $OutDir -ChildPath $file)
-        [String []] $cmds = "Get-NetAdapterStatistics -includeHidden | Format-Table -Autosize | Sort-Object InterfaceDescription | Out-String -Width $columns",
-                            "Get-NetAdapterStatistics -includeHidden | Format-Table * -Autosize | Sort-Object InterfaceDescription | Out-String -Width $columns"
+        [String []] $cmds = "Get-NetAdapterStatistics -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -Autosize  | Out-String -Width $columns",
+                            "Get-NetAdapterStatistics -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -Property * -Autosize  | Out-String -Width $columns"
     ForEach($cmd in $cmds) {
         ExecCommand -Command $cmd -Output $out
     }
@@ -1382,7 +1382,7 @@ function NetworkSummary {
     $file = "Get-NetLbfoTeam.txt"
     $out  = (Join-Path -Path $OutDir -ChildPath $file)
         [String []] $cmds = "Get-NetLbfoTeam | Sort-Object InterfaceDescription",
-                            "Get-NetLbfoTeam | Format-Table -Property * -AutoSize | Sort-Object InterfaceDescription | Out-String -Width $columns"
+                            "Get-NetLbfoTeam | Sort-Object InterfaceDescription | Format-Table -Property * -AutoSize  | Out-String -Width $columns"
     ForEach($cmd in $cmds) {
         ExecCommand -Command $cmd -Output $out
     }
@@ -1692,7 +1692,7 @@ function Counters {
     $out  = (Join-Path -Path $dir -ChildPath $file)
     # Get paths for counters of interest
     $cntrList = @("*Hyper*", "*ip*", "*udp*", "*tcp*", "*icmp*", "*nat*", "*network*", "*rdma*", "*smb*", "*wfp*", "*Mellanox*", "*intel*")
-    $cntrPaths = Get-Counter -ListSet $cntrList | Sort-Object CounterSetName | ForEach-Object { $_.Paths }
+    $cntrPaths = Get-Counter -ListSet $cntrList -ErrorAction SilentlyContinue | Sort-Object CounterSetName | ForEach-Object { $_.Paths }
 
     Write-Host "Querying Perf Counters..."
     # TODO should keep taking samples until all other jobs complete
@@ -1734,13 +1734,15 @@ function Metadata {
     [CmdletBinding()]
     Param(
         [parameter(Mandatory=$true)] [String] $OutDir,
-        [parameter(Mandatory=$true)] [Collections.Generic.Dictionary`2+Enumerator[String, Object]] $Params
+        [parameter(Mandatory=$true)] [Hashtable] $Params
     )
+
+    $paramStr = if ($Params.Count -eq 0) {"None"} else {Write-Output @Params}
 
     $file = "Metadata.txt"
     $out = (Join-Path -Path $OutDir -ChildPath $file)
-    [String []] $cmds = "Write-Output ""Version: $version"", ""Parameters: $Params"" | Out-String -Width $columns",
-                        "Get-FileHash -Path $($MyInvocation.PSCommandPath) -Algorithm ""SHA256"" | Format-List -Property * | Out-String -Width $columns"
+    [String []] $cmds = "Write-Output ""Version: $version"", ""Parameters: $paramStr"" | Out-String -Width $columns",
+                        "Get-FileHash -Path $PSCommandPath -Algorithm ""SHA256"" | Format-List -Property * | Out-String -Width $columns"
     ForEach($cmd in $cmds) {
         ExecCommand -Command ($cmd) -Output $out
     }
@@ -1832,21 +1834,21 @@ function NormalizeWorkDir {
         [parameter(Mandatory=$false)] [String] $OutputDirectory
     )
 
-    # Validate user input or use desktop if none
-    $baseDir = If ($OutputDirectory) {
-                   If (Test-Path $OutputDirectory) {
+    # Output dir priority - $OutputDirectory, Desktop, Temp
+    $baseDir = if ($OutputDirectory) {
+                   if (Test-Path $OutputDirectory) {
                        (Resolve-Path $OutputDirectory).Path # full path
-                   } Else {
-                       Throw "Get-NetView : The directory '$OutputDirectory' does not exist."
+                   } else {
+                       throw "Get-NetView : The directory ""$OutputDirectory"" does not exist."
                    }
-               } ElseIf (($desktop = [Environment]::GetFolderPath("Desktop"))) {
+               } elseif (($desktop = [Environment]::GetFolderPath("Desktop"))) {
                    $desktop
-               } Else {
-                   $env:temp
+               } else {
+                   $env:TEMP
                }
-    $workDirName = "msdbg." + $env:computername
+    $workDirName = "msdbg.$env:COMPUTERNAME"
 
-    return Join-Path $baseDir $workDirName
+    return (Join-Path $baseDir $workDirName).TrimEnd("\")
 } # NormalizeWorkDir()
 
 function EnvDestroy {
@@ -1867,10 +1869,10 @@ function EnvCreate {
     )
 
     # Attempt to create working directory, fail gracefully otherwise
-    Try {
+    try {
         New-Item -ItemType directory -Path $OutDir -ErrorAction Stop | Out-Null
-    } Catch {
-        Throw ("Get-NetView : Failed to create directory '$OutDir' because " + $error[0])
+    } catch {
+        throw "Get-NetView : Failed to create directory ""$OutDir"" because " + $error[0]
     }
 } # EnvCreate()
 
@@ -1942,15 +1944,14 @@ function Worker {
 
     # Input Validation
     CheckAdminPrivileges $SkipAdminCheck
-    $workDir   = (NormalizeWorkDir $OutputDirectory)
+    $workDir = NormalizeWorkDir -OutputDirectory $OutputDirectory
 
     EnvSetup          -OutDir $workDir
 
     # Start Run
     Clear-Host
 
-    Metadata          -OutDir $workDir -Params $PSBoundParameters.GetEnumerator()
-    HostInfo          -OutDir $workDir
+    Metadata          -OutDir $workDir -Params $PSBoundParameters
     Environment       -OutDir $workDir
     NetworkSummary    -OutDir $workDir
     

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -1449,6 +1449,14 @@ function SMBDetail {
     ForEach($cmd in $cmds) {
         ExecCommand -Command ($cmd) -Output $out
     }
+
+    $file = "Get-SmbMultichannelConstraint.txt"
+    $out = (Join-Path -Path $dir -ChildPath $file)
+    [String []] $cmds = "Get-SmbMultichannelConstraint",
+                        "Get-SmbMultichannelConstraint | Get-Member"
+    ForEach($cmd in $cmds) {
+        ExecCommand -Command ($cmd) -Output $out
+    }
 } # SMBDetail()
 
 function NetSetupDetail {

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -789,6 +789,161 @@ function MyVendorDetail {
     }
 } # MyVendorDetail()
 
+function ChelsioDetail {
+    [CmdletBinding()]
+    Param(
+        [parameter(Mandatory=$true)] [String] $IfIndex,
+        [parameter(Mandatory=$true)] [String] $OutDir
+    )
+
+    # This only needs to be run once, but this function is called per Nic
+    $dir = (Join-Path -Path $OutDir -ChildPath "ChelsioDetail")
+    if (-not (Test-Path -Path $dir)) {
+        New-Item -ItemType Directory -Path $dir | Out-Null
+
+        # Collect Chelsio related event logs and miscellaneous details
+        $file = "ChelsioDetail-Eventlog-BusDevice.txt"
+        $out = (Join-Path -Path $dir -ChildPath $file)
+        [String []] $cmds = "Get-EventLog -LogName System -Source ""*chvbd*"" | Format-List",
+                            "Get-EventLog -LogName System -Source ""*cht4vbd*"" | Format-List"
+        foreach ($cmd in $cmds) {
+            ExecCommand -Command $cmd -Output $out
+        }
+
+        $file = "ChelsioDetail-Eventlog-NetDevice.txt"
+        $out = (Join-Path -Path $dir -ChildPath $file)
+        [String []] $cmds = "Get-EventLog -LogName System -Source ""*chndis*"" | Format-List",
+                            "Get-EventLog -LogName System -Source ""*chnet*"" | Format-List",
+                            "Get-EventLog -LogName System -Source ""*cht4ndis*"" | Format-List"
+        foreach ($cmd in $cmds) {
+            ExecCommand -Command $cmd -Output $out
+        }
+
+        $file = "ChelsioDetail-Misc.txt"
+        $out = (Join-Path -Path $dir -ChildPath $file)
+        [String []] $cmds = "verifier /query",
+                            "Get-PnpDevice -FriendlyName ""*Chelsio*Enumerator*"" | Get-PnpDeviceProperty -KeyName DEVPKEY_Device_DriverVersion | Format-Table -Autosize"
+        foreach ($cmd in $cmds) {
+            ExecCommand -Command $cmd -Output $out
+        }
+    }
+
+    # Basic sanity check. Most of Chelsio related logs are collected using cxgbtool.exe.
+    # So if cxgbtool.exe is not there in System32 forlder, then exit from the function.
+    $cxgbtool = Get-Item "$env:windir\System32\cxgbtool.exe" -ErrorAction SilentlyContinue
+    if ($cxgbtool.Exists -eq $null) {
+        Write-Warning "Unable to collect Chelsio debug logs as cxgbtool is not present in $env:windir\system32"
+        return $null
+    }
+
+    $ifName = (Get-NetAdapter -InterfaceIndex $IfIndex).Name
+    $ifHwInfo = Get-NetAdapterHardwareInfo -Name "$ifName"
+    $dirBusName = "BusDev_" + $ifHwInfo.Bus + "_" + $ifHwInfo.Device + "_" + $ifHwInfo.Function
+    $dirBus = (Join-Path -Path $dir -ChildPath $dirBusName)
+
+    if (-not (Test-Path $dirBus)) { # run once
+        New-Item -ItemType Directory -Path $dirBus | Out-Null
+
+        # Enumerate VBD
+        [String] $ifNameVbd = $null
+        [Array] $PnPDevices = Get-PnpDevice -FriendlyName "*Chelsio*Enumerator*" | where {$_.Status -eq "OK"}
+        for ($i = 0; $i -lt $PnPDevices.Count; $i++) {
+            $instanceId = $PnPDevices[$i].InstanceId
+            $locationInfo = (Get-PnpDeviceProperty -InstanceId "$instanceId" -KeyName "DEVPKEY_Device_LocationInfo").Data
+            if ($ifHwInfo.LocationInformationString -eq $locationInfo) {
+                $ifNameVbd = "vbd$i"
+                break
+            }
+        }
+
+        if ([String]::IsNullOrEmpty($ifNameVbd)) {
+            Write-Warning "Couldn't resolve interface name for bus device"
+            return $null
+        }
+
+        $file = "ChelsioDetail-Cudbg.txt"
+        $CollectFile = "Cudbg-Collect.dmp"
+        $ReadFlashFile = "Cudbg-Readflash.dmp"
+        $out  = (Join-Path -Path $dirBus -ChildPath $file)
+        $OutCollect = (Join-Path -Path $dirBus -ChildPath $CollectFile)
+        $OutReadFlash = (Join-Path -Path $dirBus -ChildPath $ReadFlashFile)
+        [String []] $cmds = "cxgbtool.exe $ifNameVbd cudbg collect all $OutCollect",
+                            "cxgbtool.exe $ifNameVbd cudbg readflash $OutReadFlash"
+        foreach ($cmd in $cmds) {
+            ExecCommand -Trusted -Command $cmd -Output $out
+        }
+
+        $file = "ChelsioDetail-Firmware-BusDevice$i.txt"
+        $out  = (Join-Path -Path $dirBus -ChildPath $file)
+        [String []] $cmds = "cxgbtool.exe $ifNameVbd firmware mbox 1",
+                            "cxgbtool.exe $ifNameVbd firmware mbox 2",
+                            "cxgbtool.exe $ifNameVbd firmware mbox 3",
+                            "cxgbtool.exe $ifNameVbd firmware mbox 4",
+                            "cxgbtool.exe $ifNameVbd firmware mbox 5",
+                            "cxgbtool.exe $ifNameVbd firmware mbox 6",
+                            "cxgbtool.exe $ifNameVbd firmware mbox 7"
+        foreach ($cmd in $cmds) {
+            ExecCommand -Command $cmd -Output $out
+        }
+
+        $file = "ChelsioDetail-Hardware-BusDevice$i.txt"
+        $flashFile = "Hardware-BusDevice$i-flash.dmp"
+        $out = (Join-Path -Path $dirBus -ChildPath $file)
+        $OutFlash = (Join-Path -Path $dirBus -ChildPath $flashFile)
+        [String []] $cmds = "cxgbtool.exe $ifNameVbd hardware sgedbg",
+                            "cxgbtool.exe $ifNameVbd hardware flash $OutFlash"
+        foreach ($cmd in $cmds) {
+            ExecCommand -Command $cmd -Output $out
+        }
+    }
+
+    $dirNetName = "NetDev_$IfIndex"
+    $dirNet = (Join-Path -Path $dir -ChildPath $dirNetName)
+    New-Item -ItemType Directory -Path $dirNet | Out-Null
+
+    # Enumerate NIC
+    [Array] $NetDevices = Get-NetAdapter -InterfaceDescription "*Chelsio*" | where {$_.Status -eq "Up"} | Sort-Object -Property MacAddress
+    $ifNameNic = $null
+    for ($i = 0; $i -lt $NetDevices.Count; $i++) {
+        if ($ifName -eq $NetDevices[$i].Name) {
+            $ifNameNic = "nic$i"
+            break
+        }
+    }
+
+    if ([String]::IsNullOrEmpty($ifNameNic)) {
+        Write-Warning "Couldn't resolve interface name for Network device(IFIndex:$IfIndex)"
+        return $null
+    }
+
+    $file = "ChelsioDetail-Debug.txt"
+    $out  = (Join-Path -Path $dirNet -ChildPath $file)
+    [String []] $cmds = "cxgbtool.exe $ifNameNic debug filter",
+                        "cxgbtool.exe $ifNameNic debug qsets",
+                        "cxgbtool.exe $ifNameNic debug qstats txeth rxeth txvirt rxvirt txrdma rxrdma txnvgre rxnvgre",
+                        "cxgbtool.exe $ifNameNic debug dumpctx",
+                        "cxgbtool.exe $ifNameNic debug version",
+                        "cxgbtool.exe $ifNameNic debug eps",
+                        "cxgbtool.exe $ifNameNic debug qps",
+                        "cxgbtool.exe $ifNameNic debug rdma_stats",
+                        "cxgbtool.exe $ifNameNic debug stags",
+                        "cxgbtool.exe $ifNameNic debug l2t"
+    foreach ($cmd in $cmds) {
+        ExecCommand -Command $cmd -Output $out
+    }
+
+    $file = "ChelsioDetail-Hardware.txt"
+    $out  = (Join-Path -Path $dirNet -ChildPath $file)
+    [String []] $cmds = "cxgbtool.exe $ifNameNic hardware tid_info",
+                        "cxgbtool.exe $ifNameNic hardware fec",
+                        "cxgbtool.exe $ifNameNic hardware link_cfg",
+                        "cxgbtool.exe $ifNameNic hardware pktfilter",
+                        "cxgbtool.exe $ifNameNic hardware sensor"
+    foreach ($cmd in $cmds) {
+        ExecCommand -Command $cmd -Output $out
+    }
+} # ChelsioDetail()
+
 function NicVendor {
     [CmdletBinding()]
     Param(
@@ -801,10 +956,10 @@ function NicVendor {
     foreach ($nic in Get-NetAdapter) {
         $pciId = (Get-NetAdapterAdvancedProperty -Name $nic.Name -AllProperties -RegistryKeyword "ComponentID").RegistryValue
         switch -Wildcard($pciId) {
+            "CHT*BUS\chnet*" {
+                ChelsioDetail $nic.ifIndex $dir
+            }
             # Not implemented
-            #"PCI\VEN_1425*" {
-            #    ChelsioDetail $nic.ifIndex $dir
-            #}
             #"PCI\VEN_15B3*" {
             #    MellanoxDetail $nic.ifIndex $dir
             #}
@@ -1104,7 +1259,7 @@ function VmWorker {
     ForEach($cmd in $cmds) {
         ExecCommand -Command ($cmd) -Output $out
     }
-    
+
     $file = "Get-VMHardDiskDrive.txt"
     $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMHardDiskDrive -VMName $VMName | Out-String -Width $columns",
@@ -1457,6 +1612,14 @@ function SMBDetail {
     ForEach($cmd in $cmds) {
         ExecCommand -Command ($cmd) -Output $out
     }
+
+    $file = "Smb-WindowsEvents.txt"
+    $out  = (Join-Path -Path $dir -ChildPath $file)
+    [String []] $cmds = "Get-WinEvent -ListLog ""*SMB*"" | Format-List -Property *",
+                        "Get-WinEvent -ListLog ""*SMB*"" | Get-WinEvent | ? Message -like ""*RDMA*"" | Format-List -Property *"
+    ForEach($cmd in $cmds) {
+        ExecCommand -Command ($cmd) -Output $out
+    }
 } # SMBDetail()
 
 function NetSetupDetail {
@@ -1478,7 +1641,7 @@ function NetSetupDetail {
         ExecCommand -Command ($cmd) -Output $out
     }
 
-    # Copy over the logs      
+    # Copy over the logs
     [String []] $cmds = "C:\Windows\System32\NetSetupMig.log",
                         "C:\Windows\Panther\setupact.log",
                         "C:\Windows\INF\setupapi.*",
@@ -1488,7 +1651,7 @@ function NetSetupDetail {
             $tcmd = "Copy-Item $cmd $dir -recurse -verbose 4>&1"
             ExecCommand -Trusted -Command ($tcmd) -Output $out
         }
-    }   
+    }
 } # NetSetupDetail()
 
 function QosDetail {
@@ -1557,7 +1720,7 @@ function ServicesDrivers {
     ForEach($cmd in $cmds) {
         ExecCommand -Command $cmd -Output $out
     }
-    
+
     $file = "Get-Service.txt"
     $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-Service ""*"" | Sort-Object name",
@@ -1565,7 +1728,7 @@ function ServicesDrivers {
     ForEach($cmd in $cmds) {
         ExecCommand -Command $cmd -Output $out
     }
-    
+
     $file = "Get-WindowsDriver.txt"
     $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-WindowsDriver -Online -All" # very slow, -Trusted to skip validation
@@ -1962,10 +2125,10 @@ function Worker {
     Metadata          -OutDir $workDir -Params $PSBoundParameters
     Environment       -OutDir $workDir
     NetworkSummary    -OutDir $workDir
-    
+
     HwErrorReport     -OutDir $workDir
     LogsReport        -OutDir $workDir
-     
+
     NetSetupDetail    -OutDir $workDir
     VMSwitchDetail    -OutDir $workDir
     LbfoDetail        -OutDir $workDir


### PR DESCRIPTION
I recommended examining this PR by commit.

1. Simplified ExexCommands: added -Trusted switch to ExecCommand, replacing ExecCommandTrusted
2. Fixes Format-Table being in wrong order of pipeline for some commands. Also some consistency changes.
3. Adds Get-SmbMultichannelConstraint query for SMB
4. Changes that Chelsio submitted. They did a very good job, so the only noteworthy change I made was moving the cxgbtool check down a bit.

Unfortunately, there is an architectural flaw with how we designed the IHV functions. Namely, we didn't give a way to easily run commands only once (e.g. for all Chelsio NICs). They were able to work around it, but this should fixed for future submissions.