### PR TITLE
K8s guide feedback and formatting

### DIFF
--- a/Kubernetes/HOWTO-on-prem.md
+++ b/Kubernetes/HOWTO-on-prem.md
@@ -1,11 +1,21 @@
 # Kubernetes On-Premises Deployment From Scratch -- Start to Finish #
 This guide will walk you through deploying *Kubernetes 1.8* on a Linux master and join two Windows nodes to it without a cloud provider.
 
+## Assumptions and Prerequisites ##
+
+It is assumed you will be setting up the following:
+
+- 1 Linux VM/host on an Ubuntu like OS. This will be the single master
+- 2 Windows Server 2016 RS3+ VM/host as worker nodes
+- Compilation of required binaries specific to this exercise can be done on the Linux host above, or a temporary Linux host via Vagrant, custom VM, or otherwise.
+- Cluster subnet is assumed to be 192.168.0.0/16 but could be specified otherwise. Changes to this value are not covered.
+- Service subnet is assumed to be 11.0.0.0/16 and is hardcoded throughout this repo. Changes to this value are not covered.
+
 A few prerequisite definitions and requirements for networking:
 
-  - The **external network** is the physical network across which nodes communicate. This exists regardless of whether or not you follow this guide.
-  - The **cluster subnet** is a (<a href="#allow-routing">routable</a>) virtual network that must be a /16. Each _node_ will grab a /24 from the subnet to use for its pods.
-  - The **service subnet** is a hardcoded 11.0/16 network that is translated into cluster space by `kube-proxy` running on the node.
+- The **external network** is the physical network across which nodes communicate. This exists regardless of whether or not you follow this guide.
+- The **cluster subnet** is a (<a href="#allow-routing">routable</a>) virtual network that must be a /16. Each _node_ will grab a /24 from the subnet to use for its pods.
+- The **service subnet** is a hardcoded 11.0/16 network that is translated into cluster space by `kube-proxy` running on the node.
 
 **Note**: The guide will assume a local working directory of `~/kube` for the Kubernetes setup. If you choose a different directory, just replace any references to that path.
 
@@ -17,42 +27,61 @@ First, install all of the pre-requisites on the master:
     $ sudo apt-get install git build-essential docker.io
 
 ### Building Kubernetes ###
-We will need to build the `kubelet` and `kubeproxy` binaries for Windows from scratch _cross-compiling from Linux_, so let's [set up a Go environment](https://golang.org/doc/install#install) for that, first. This guide assumes Go 1.9 and has not been tested with anything else. With your Go environment ready (don't forget to set your `$GOPATH`!), we can build the Windows binaries:
+We will need to build the `kubelet` and `kubeproxy` binaries for Windows from scratch _cross-compiling from Linux_, so is a non-issue by leveraging the [standard containerized build scripts](https://github.com/kubernetes/kubernetes/tree/master/build#key-scripts) leveraged in the Kubernetes project.
 
-_You may run into problems with various "permission denied" errors when building these binaries. This is a bug in the Kubernetes build process for Windows, which uses binaries that exist but are size-zero, and thus don't have executable permissions on them. The unfortunate solution is to run `chmod +x _output/bin/*` after every time (~4 times) you hit the error._
+Various permission denied errors are avoided by building the linux kubelet first, per the note at [acs-engine](https://github.com/Azure/acs-engine/blob/master/scripts/build-windows-k8s.sh#L176) of
+> Due to what appears to be a bug in the Kubernetes Windows build system, one has to first build a linux binary to generate _output/bin/deepcopy-gen. Building to Windows w/o doing this will generate an empty deepcopy-gen.
+
+You can optionally execute this in a Vagrant box
 
 ```bash
-$ K8SREPO="github.com/madhanrm/kubernetes"
-$ go get -d $K8SREPO
-# Note: the above command may spit out a warning about "no Go files in...", but
-#       it can be safely ignored!
-$ cd $GOPATH/src/$K8SREPO
-$ git checkout cniwindows
-$ make clean && make WHAT=cmd/kubelet
-$ export KUBE_BUILD_PLATFORMS=windows/amd64
-$ make WHAT=cmd/kubelet
-$ cp _output/local/bin/windows/amd64/kubelet.exe ~/kube/
-$ git checkout winkernelproxy 
-$ make WHAT=cmd/kube-proxy
-$ cp /_output/local/bin/windows/amd64/kube-proxy.exe ~/kube/
-$ unset KUBE_BUILD_PLATFORMS
+DIST_DIR="${HOME}/kube/"
+mkdir ${DIST_DIR}
+SRC_DIR="${HOME}/src/kubernetes/"
+mkdir -p "${SRC_DIR}"
+git clone https://github.com/madhanrm/kubernetes.git ${SRC_DIR}
+cd ${SRC_DIR}
+git checkout cniwindows
+build/run.sh make WHAT=cmd/kubelet KUBE_BUILD_PLATFORMS=linux/amd64
+build/run.sh make WHAT=cmd/kubelet KUBE_BUILD_PLATFORMS=windows/amd64
+cp ${SRC_DIR}/_output/dockerized/bin/windows/amd64/kubelet.exe ${DIST_DIR}
+#winkernelproxy has already been merged but still needs to be built
+git checkout winkernelproxy 
+build/run.sh make WHAT=cmd/kube-proxy KUBE_BUILD_PLATFORMS=windows/amd64
+cp ${SRC_DIR}/_output/dockerized/bin/windows/amd64/kube-proxy.exe ${DIST_DIR}
+ls ${DIST_DIR}
 ```
 
-Done! Now, we also need the actual Linux Kubernetes binaries for v1.8. You can pull these from [the Kubernetes mainline](https://github.com/kubernetes/kubernetes/releases/tag/v1.8.0-rc.1), or build them from source as above, except using `K8SREPO=k8s.io/kubernetes` and the `release-1.8` branch, stopping before the `export ...` line. 
+Done! Now, we also need the actual Linux Kubernetes binaries for v1.8. You can pull these from [the Kubernetes mainline](https://github.com/kubernetes/kubernetes/releases/tag/v1.8.0), or build them from source as above, except using `K8SREPO=k8s.io/kubernetes` and the `release-1.8` branch, stopping before the `export ...` line.
 
 If you built them from source, copy the binaries (at least `hyperkube`, `kubectl`, and `kubeadm`) directly to `~/kube/bin`. Otherwise, you will need to extract the downloaded archive and run the `cluster/get-kube-binaries.sh` script before copying the binaries.
 
  Copy these to `~/kube/bin` (note the extra `/bin` compared to the above path; we actual need to use these during master configuration, rather than just copying them to the Windows node). The v1.8 Windows binary `kubectl.exe` is included in the `windows/` directory of this repo, but you can also build it here (setting `KUBE_BUILD_PLATFORMS=windows/amd64` and `WHAT=cmd/kubectl` as above).
 
 ### Install CNI Plugins ###
+
 We also need to install the basic CNI plugin binaries so that networking works. Download them from [here](https://github.com/containernetworking/plugins/releases) and copy them to `/opt/cni/bin/`.
 
+```bash
+DOWNLOAD_DIR="${HOME}/kube/cni-plugins"
+CNI_BIN="/opt/cni/bin/"
+mkdir ${DOWNLOAD_DIR}
+cd $DOWNLOAD_DIR
+curl -L $(curl -s https://api.github.com/repos/containernetworking/plugins/releases/latest | grep browser_download_url | grep 'amd64.*tgz' | head -n 1 | cut -d '"' -f 4) -o cni-plugins-amd64.tgz
+tar -xvzf cni-plugins-amd64.tgz
+sudo mkdir -p ${CNI_BIN}
+sudo cp -r !(*.tgz) ${CNI_BIN}
+ls ${CNI_BIN}
+```
+
 ## Prepare the Master ##
-Copy the entire directory from [this repository](https://github.com/Microsoft/SDN/tree/master/Kubernetes/linux), which contains a lot of the setup scripts and Kubernetes files that are essential to this process. Check them all out to `~/kube/` and make the scripts executable. This entire directory will be getting mounted for a lot of the docker containers in future steps, so keep its structure the same as outlined in the guide. 
+
+Copy the entire directory from [this repository](https://github.com/Microsoft/SDN/tree/master/Kubernetes/linux), which contains a lot of the setup scripts and Kubernetes files that are essential to this process. Check them all out to `~/kube/` and make the scripts executable. This entire directory will be getting mounted for a lot of the docker containers in future steps, so keep its structure the same as outlined in the guide.
 
 We'll be creating the service cluster on the virtual subnet 11.0/16. This isn't configurable, so if you want to tweak this, it'll require manual modification.
 
 ### Certificates ###
+
 First, prepare the certificates that will be used for nodes to communicate in the cluster. Create a `certs/` directory, then move & run `generate-certs.sh` passing **your** external IP as its (only) parameter -- this is likely whatever the IP address of your `eth0` interface is. You can acquire this through `ifconfig` or through:
 
     $ ip addr show dev eth0
@@ -64,6 +93,7 @@ if you already know the interface name. Then:
     ~/kube/certs $ ./generate-certs.sh 10.123.45.67   # example! replace
 
 ### Allow Routing ###
+
 _This step may be optional, depending on whether or not you've configured your intended cluster subnet to be routable already_.
 
 Windows nodes will each grab a /24 from the cluster CIDR, so it's 192.168.0.0/16, the first Windows node will use 192.168.0.1/24 for its pods. Pass the first two octets of your clister CIDR to generate the routes:
@@ -71,6 +101,7 @@ Windows nodes will each grab a /24 from the cluster CIDR, so it's 192.168.0.0/16
     ~/kube $ generate-routes.sh 192.168
 
 ### Prepare Manifests & Addons ###
+
 In the `manifest` folder, run the Python script, passing your master IP and the _full_ cluster CIDR:
 
     $ python2 generate.py 10.123.45.67 192.168.0.0/16
@@ -78,6 +109,7 @@ In the `manifest` folder, run the Python script, passing your master IP and the 
 This will generate a set of YAML files. You should [re]move the Python script so that K8s doesn't mistake it for a manifest and cause problems.
 
 ### Configure & Run Kubernetes ###
+
 Run the script `configure-kubectl.sh` passing your external IP again. This will create a configuration in `~/.kube/config` containing all of the certificate data and other parameters:
 
     ~/kube $ ./configure-kubectl.sh 10.123.45.67
@@ -86,7 +118,7 @@ Run the script `start-kubelet.sh`. You may need to run it with `sudo`. Then, in 
 
     ~/kube $ sudo cp ~/.kube/config kubelet/
 
-**TODO**: Why is this necessary? Shouldn't this be done automatically by one of the containers?
+**TODO**: Why is this necessary? Shouldn't this be done automatically by one of the containers? **What does this do?**
 
 In another terminal session, run the Kubeproxy script, passing your cluster CIDR (you may also need to run this one with `sudo`):
 
@@ -94,29 +126,45 @@ In another terminal session, run the Kubeproxy script, passing your cluster CIDR
 
 After a few minutes, you should see the following system state:
 
-  - Under `docker ps`, you should see worker and pod containers mirroring the configs in `manifest/` and in `addons/`.
-  - A call to `~/kube/bin/kubectl cluster-info` should show info for the Kubernetes master API server, plus the DNS and heapster addons.
-  - A new interface `cbr0` under `ifconfig`, with your chosen cluster CIDR.
+- Under `docker ps`, you should see worker and pod containers mirroring the configs in `manifest/` and in `addons/`.
+- A call to `~/kube/bin/kubectl cluster-info` should show info for the Kubernetes master API server, plus the DNS and heapster addons.
+- A new interface `cbr0` under `ifconfig`, with your chosen cluster CIDR.
+
+## Prepare a Windows Node ##
+
+We need a baseline of configuration on Windows nodes. This assumes Windows Server 2016, RS3+. This can be in a hypervisor or otherwise, but the instances require a external network IP (accessible by other hosts, not the public internet).
+
+The following is for current insider builds, at an *elevated* Powershell prompt
+
+```powershell
+Install-Module -Name DockerMsftProviderInsider -Repository PSGallery -Force
+Install-Package -Name docker -ProviderName DockerMsftProviderInsider -RequiredVersion preview
+Restart-Computer -Force
+```
 
 ## Join a Windows Node ##
+
 Like for Linux, we need an assortment of scripts to prepare things for us. They can be found [here](https://github.com/Microsoft/SDN/tree/master/Kubernetes/windows). Place these in a new folder, `C:\k\`. We also need to copy the .exe binaries we compiled earlier (which we placed in `~/kube/`), as well as the Kubectl config file (from `~/.kube/config`), into this folder. This can be done with something like [WinSCP](https://winscp.net/eng/download.php) or [pscp](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html).
 
 ### Build Docker Image ###
-We need to build the docker image for the Kubernetes infrastructure. Navigate
-to `C:\k\` and run:
+
+We need to build the docker image for the Kubernetes infrastructure. Navigate to `C:\k\` and run:
 
     C:\k> docker pull microsoft/windowsservercore-insider:latest
     C:\k> docker tag [SHA from previous cmd] microsoft/windowsservercore:latest
-    C:\k> docker build -t kubletwin/pause .
+    C:\k> docker build -t kubeletwin/pause .
+
+**Note:** the Windows Server Core Insider image is retagged as non-insider to avoid extra changes once it becomes non-insder
 
 ### Join to Cluster ###
+
 In two PowerShell windows, simply run:
 
     PS> ./start-kubelet.ps1 -ClusterCidr [Full cluster CIDR]
     PS> ./start-kubeproxy.ps1
 
-(in that order). You should be able to see the Windows node when running `./bin/kubectl get nodes` on the Linux master, shortly!
+(in that order). You should be able to see the Windows node when running `./bin/kubectl get nodes` on the Linux master, shortly!)
 
 Now, if your cluster CIDR isn't routable, just run this in PowerShell:
 
-    C:\k> AddRoutes.ps1 -MasterIp [Linux Master]
+    C:\k> AddRoutes.ps1 -MasterIp [Linux Master IP]

--- a/Kubernetes/linux/vagrant/Vagrantfile
+++ b/Kubernetes/linux/vagrant/Vagrantfile
@@ -1,0 +1,21 @@
+$VirtualSwitchName = "External"
+
+LINUX_IMAGE = "kmm/ubuntu-xenial64"
+
+Vagrant.configure("2") do |config|
+    config.vm.provider "hyperv" do |h|
+        h.enable_virtualization_extensions = true
+        h.differencing_disk = true
+        h.cpus = 4
+        h.memory = 1024
+        h.maxmemory = 2048
+        h.vmname = "k8s-master"
+    end    
+    config.vm.define "k8s-master" do |subconfig|
+        subconfig.vm.box = LINUX_IMAGE
+        subconfig.vm.hostname = "k8s-master"
+        subconfig.vm.network :public_network, bridge: $VirtualSwitchName
+        config.vm.synced_folder ".", "/vagrant", disabled: true
+        subconfig.vm.provision "shell", path: "ubuntu.sh"
+    end
+end

--- a/Kubernetes/linux/vagrant/readme.md
+++ b/Kubernetes/linux/vagrant/readme.md
@@ -1,0 +1,10 @@
+# Usage
+
+- Leverage this ubuntu box as an easy way for primarily Windows users to compile k8s
+- Reference on requirements for Ubuntu 16.04 to not run into delays/issues
+
+## Typical usage
+
+- `vagrant up`
+- `vagrant ssh`
+- Run commands in main readme to compile k8s for linux and windows. Copy out files via SCP or other tools

--- a/Kubernetes/linux/vagrant/ubuntu.sh
+++ b/Kubernetes/linux/vagrant/ubuntu.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+echo "Starting bootstrap"
+
+systemctl stop apt-daily.service
+systemctl kill --kill-who=all apt-daily.service
+
+# wait until `apt-get updated` has been killed
+while ! (systemctl list-units --all apt-daily.service | fgrep -q dead)
+do
+  echo "apt-daily still running"
+  sleep 1;
+done
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+
+apt update
+
+apt install -y git build-essential docker-ce 

--- a/Kubernetes/windows/start-kubelet.ps1
+++ b/Kubernetes/windows/start-kubelet.ps1
@@ -108,7 +108,7 @@ $podCidrDiscovered = Test-PodCIDR $podCIDR
 # if the podCIDR has not yet been assigned to this node, start the kubelet process to get the podCIDR, and then promptly kill it.
 if (-not $podCidrDiscovered)
 {
-    $argList = @("--hostname-override=$(hostname)","--pod-infra-container-image=kubletwin/pause","--resolv-conf=""""", "--kubeconfig=c:\k\config")
+    $argList = @("--hostname-override=$(hostname)","--pod-infra-container-image=kubeletwin/pause","--resolv-conf=""""", "--kubeconfig=c:\k\config")
 
     $process = Start-Process -FilePath c:\k\kubelet.exe -PassThru -ArgumentList $argList
 
@@ -149,4 +149,4 @@ Start-Sleep 10
 # Add route to all other POD networks
 Update-CNIConfig $podCIDR
 
-c:\k\kubelet.exe --hostname-override=$(hostname) --pod-infra-container-image=kubletwin/pause --resolv-conf="" --allow-privileged=true --enable-debugging-handlers --cluster-dns=$KubeDnsServiceIp --cluster-domain=cluster.local  --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge --v=6 --image-pull-progress-deadline=20m --cgroups-per-qos=false --enforce-node-allocatable="" --network-plugin=cni --cni-bin-dir=$CNIPath --cni-conf-dir $CNIPath\config
+c:\k\kubelet.exe --hostname-override=$(hostname) --pod-infra-container-image=kubeletwin/pause --resolv-conf="" --allow-privileged=true --enable-debugging-handlers --cluster-dns=$KubeDnsServiceIp --cluster-domain=cluster.local  --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge --v=6 --image-pull-progress-deadline=20m --cgroups-per-qos=false --enforce-node-allocatable="" --network-plugin=cni --cni-bin-dir=$CNIPath --cni-conf-dir $CNIPath\config


### PR DESCRIPTION
This addresses some of the issues I had faced in recent testing, before I had access to the Linux shell scripts. It also addresses some of the recent PR feedback on the base repo/branch.

Primary changes include:
- Leverage standard k8s containerized build scripts to avoid go environment assumptions/problems
- Integrate lessons learned on compilation from acs-engine
- Addressing some of the concerns on the primary audience having less Linux experience
- Minor scripting additions to streamline steps such as CNI plugins
- Setup steps for Windows nodes
- Rename of pause infrastructure container to be `kubelet`

I have not been able to test end to end yet. This is what I've found so far, and with recent churn I'd like to submit this to help address issues in flight.