### PR TITLE
Improve Get-VSwitchPathCost.ps1 performance

### DIFF
--- a/Diagnostics/Get-VSwitchPathCost.ps1
+++ b/Diagnostics/Get-VSwitchPathCost.ps1
@@ -213,8 +213,6 @@ $output = (((Receive-Job $counterJob).Readings | Out-String) -replace ":`n",": "
 Remove-Job $counterJob
 
 $hostCounterRxBytesPerSecAvg = Get-CounterAverage ($output -like "*($SwitchName)\Bytes Sent/sec*")
-$hostCounterRxBytesPerSecAvg *= 8
-
 $hostCounterRxPktsPerSecAvg = Get-CounterAverage ($output -like "*($SwitchName)\Packets Sent/sec*")
 
 # Per proc host VP runtime
@@ -255,7 +253,7 @@ $statistics = @(
     @("CPU speed (cycles per second)", $cpuCyclesPerSec),
     @("VP Utilization", [Math]::Round($hostVPRuntime, 2)),
     @("Total CPU cycles used per second", [Math]::Round($totalCyclesPerSec, 2)),
-    @("Bytes/s received through vswitch", [Math]::Round($hostCounterRxBytesPerSecAvg, 2)),
+    @("Mbps received through vswitch", [Math]::Round((8 * $hostCounterRxBytesPerSecAvg) / 1MB, 2)),
     @("Packets/s received through vswitch", [Math]::Round($hostCounterRxPktsPerSecAvg, 2)),
     @("Byte path cost (cycles/byte)", [Math]::Round($bytePathCost, 2)),
     @("Packet path cost (cycles/packet)", [Math]::Round($pktPathCost, 2))

--- a/Diagnostics/Get-VSwitchPathCost.ps1
+++ b/Diagnostics/Get-VSwitchPathCost.ps1
@@ -1,10 +1,7 @@
 <#
 .SYNOPSIS
-
     Measures vmswitch path cost (cycles per packet) for performance benchmarking.
-
 .DESCRIPTION
-
     Query Perfmon counters to calculate vmswitch performance benchmark
         - Query packets sent by vswitch to all of its vPorts. This represents the amount
         of useful work a vswitch can do (i.e. measured in terms of how many packets it
@@ -12,63 +9,44 @@
         - Query system's processor speed
         - Query processor utilization
         - Calculate path cost, based on the above information
-
 .PARAMETER DurationInSeconds
-
     Required parameter that specifies how long the script should collect information.
     This time period does not include the warmup and cooldown time.
-
 .PARAMETER SwitchName
-
     Required parameter that specifies the vswitch to query packet count from.
-
 .PARAMETER BaseCpuNumber
-
     Optional parameter that specifies the starting CPU for including in the
     CPU utilization measurement. Default value is 0.
-
 .PARAMETER MaxCpuNumber
-    
     Optional parameter that specifies the ending CPU for including in the CPU
     utilization measurement. Default value is max processor number in the system.
-
 .PARAMETER WarmUpDurationInSeconds
-
     Optional parameter that specifies warmup time that will not be included in
     the measurement. This time period will be added to DurationInSeconds for
     total runtime. Default value is 0.
-
 .PARAMETER CoolDownDurationInSeconds
-
     Optional parameter that specifies cooldown time that will not be included in
     the measurement. This time period will be added to DurationInSeconds for
     total runtime. Default value is 0.
-
 .EXAMPLE
-
     Get-VSwitchPathCost.ps1 -DurationInSeconds 30 -SwitchName MyVSwitch
-
 .NOTES
-
    This script does not start any traffic. It is the caller's responsibility to ensure
    traffic is already running in steady state, before calling the script.
    The script only collects perfmon counters for the specified during, and computes
    path cost, based on the specified CPU range.
 
-   Since CPU utilization and path cost are more accurately measured with HyperThreading
-   disabled, this script forces HyperThreading to be disabled. You can disable HyperThreading
-   in the BIOS.
-
    However, note that for better performance, HyperThreading should be enabled.
-
 #>
 
-PARAM($DurationInSeconds =$(throw "DurationInSeconds is required"),
-      $SwitchName = $(throw "SwitchName is required"),
-      $BaseCpuNumber=0,
-      $MaxCpuNumber,
-      $WarmUpDurationInSeconds=0,
-      $CoolDownDurationInSeconds=0)
+Param(
+    [Parameter(Mandatory=$true)] $DurationInSeconds,
+    [Parameter(Mandatory=$true)] $SwitchName,
+    $BaseCpuNumber = 0,
+    [Parameter(Mandatory=$false)] $MaxCpuNumber,
+    $WarmUpDurationInSeconds = 0,
+    $CoolDownDurationInSeconds = 0
+)
 
 
 function Log($Message)
@@ -88,22 +66,15 @@ function Log($Message)
     }
 }
 
+$cpuInfo = @(Get-WmiObject -Class win32_processor -Property NumberOfCores, MaxClockSpeed, NumberOfLogicalProcessors)
+
 function IsHyperThreadingEnabled()
 {
-    $cpuInfo = Get-WmiObject -Class win32_processor -Property "numberOfCores", "NumberOfLogicalProcessors"
-    if ($cpuInfo[0].NumberOfCores -lt $cpuInfo[0].NumberOfLogicalProcessors)
-    {
-        return $True
-    }
-    else
-    {
-        return $False
-    }
+    return $cpuInfo[0].NumberOfCores -lt $cpuInfo[0].NumberOfLogicalProcessors
 }
 
 function GetNumCpusPerNUMA()
 {
-    $cpuInfo = Get-WmiObject -Class win32_processor -Property "numberOfCores"
     $numcores = $cpuInfo[0].NumberOfCores
     Log "Number of cores per NUMA: $numcores"
     return $numcores
@@ -111,7 +82,6 @@ function GetNumCpusPerNUMA()
 
 function GetNumaCount()
 {
-    $cpuInfo = Get-WmiObject -Class win32_processor -Property "numberOfCores"
     $numaCount = $cpuInfo.Count
     Log "NUMA count: $numaCount"
     return $numaCount
@@ -119,59 +89,51 @@ function GetNumaCount()
 
 function GetCpuClockSpeed()
 {
-    $cpuInfo = Get-WmiObject -Class win32_processor -Property "maxclockspeed"
     return $cpuInfo[0].MaxClockSpeed
 }
 
 
 #
-# This function takes in a job ID of a Get-Counter job, and
-# retrieve the perfmon output of the job, and computes the
-# average values of the samples.
+# This function takes a specially processed array of counter results Strings
+# formatted like "<path> : <value>" and computes the average values of the samples.
 #
-function GetAverageFromGetCounterJob($JobId)
+function Get-CounterAverage([String[]] $statArray)
 {
-    Stop-Job $JobId
-    $statArray = Receive-Job $JobId
-    Remove-Job $JobId
-
-    $avg = 0
-    $count=0
+    $sum = 0
+    $count = 0
     $endIndex = $statArray.Count - 1 - $CoolDownDurationInSeconds
     $startIndex = $endIndex - $DurationInSeconds
-            
-    $message = ""
-    for ($i=$startIndex; $i -le $endIndex; $i++)
+
+    for ($i = $startIndex; $i -le $endIndex; $i++)
     {
-        $value = $statArray[$i].Readings.Split(":")[-1]
-        $value = $value.Trim()
+        $value = $statArray[$i].Split(":")[1]
+        $value = [Int64] $value.Trim()
 
-        $value = [int64]$value
-        $avg += $value
-
-        $message = $message + [string]$value + ", "
+        $sum += $value
         $count++
     }
 
-    $avg = $avg / $count
-
-    return $avg
+    return $sum / $count
 }
 
 
-###############################################################
-### Start program #############################################################
-###############################################################
+#
+# Start program
+#
 
-
-#######################################
+#
 # Sanity check the parameters & host setup
-#######################################
+#
 
-$switch = Get-Vmswitch $SwitchName
+if (IsHyperThreadingEnabled)
+{
+    Log "ERROR: Hyper-Threading is enabled. Please disable Hyper-Threading before starting the test."
+}
+
+$switch = Get-VMSwitch $SwitchName
 if ($switch -eq $null)
 {
-   Log "ERROR: Switch $SwitchName does not exist"
+    Log "ERROR: Switch $SwitchName does not exist"
 }
 
 if ($switch.Count -gt 1)
@@ -179,7 +141,7 @@ if ($switch.Count -gt 1)
     Log "ERROR: There are more than one vswitch with the name $SwitchName"
 }
 
-if ($MaxCpuNumber -eq $null)
+if (-not $PSBoundParameters.ContainsKey("MaxCpuNumber"))
 {
     $cpuPerNuma = GetNumCpusPerNUMA
     $numaCount = GetNumaCount
@@ -192,13 +154,6 @@ if ($MaxCpuNumber -lt $BaseCpuNumber)
    Log "ERROR: Max CPU number is less than base CPU number"
 }
 
-#
-# Verify HyperThreading is disabled
-#
-if (IsHyperThreadingEnabled)
-{
-    Log "ERROR: HyperThreading is enabled. Please disable HyperThreading before starting the test."
-}
 
 Log "Collecting performance stats"
 Log "DurationInSeconds:               $DurationInSeconds"
@@ -206,82 +161,63 @@ Log "BaseCpuNumber:                   $BaseCpuNumber"
 Log "MaxCpuNumber:                    $MaxCpuNumber"
 
 
-#############################################
+#
 # Start perfmon monitoring
-#############################################
+#
 Log ""
 
-$hostCounterName = (get-counter -listset "Hyper-V Virtual Switch").PathsWithInstances | where {$_ -like "*$SwitchName*\Bytes Sent/sec*"}
-$hostCounterRxBytesPerSecJob = Start-Job -ScriptBlock {param($counter) Get-Counter -Counter $counter -SampleInterval 1 -Continuous} -ArgumentList $hostCounterName
+$vSwitchCounters = (Get-Counter -ListSet "Hyper-V Virtual Switch").PathsWithInstances | where {$_ -like "*($SwitchName)\Bytes Sent/sec*" -or $_ -like "*($SwitchName)\Packets Sent/sec*"}
+$rootVPCounters = (Get-Counter -ListSet "Hyper-V Hypervisor Root Virtual Processor").PathsWithInstances | where {$_ -like "*(Root VP *)\% Total Run Time*"}
+$rootVPCounters = $rootVPCounters[(-$BaseCpuNumber-1)..(-$MaxCpuNumber-1)] # rootVPCounters is in reverse order of VP#
 
-$hostCounterName = (get-counter -listset "Hyper-V Virtual Switch").PathsWithInstances | where {$_ -like "*$SwitchName*\Packets Sent/sec*"}
-$hostCounterRxPktsPerSecJob = Start-Job -ScriptBlock {param($counter) Get-Counter -Counter $counter -SampleInterval 1 -Continuous} -ArgumentList $hostCounterName
+$allCounters = $vSwitchCounters + $rootVPCounters
 
+Log "Starting counter collection"
+$counterJob = Start-Job -ScriptBlock {param($counters) Get-Counter -Counter $counters -Continuous -SampleInterval 1} -ArgumentList (,$allCounters)
 
-#
-# Collect host VP utilization
-#
-Log "Start collecing host VP utilization ..."
-$hostVPPerProcRuntimeJobs = @()
-for ($i=$BaseCpuNumber; $i -le $MaxCpuNumber; $i++)
+Log "Waiting for counter collection to start..."
+$value = Receive-Job $counterJob -Keep
+while ($value.Count -lt 1)
 {
-    Log "`tStart collecting VP utilization for VP $i ..."
-    $jobObj = Start-Job -ScriptBlock {param($procId) Get-Counter -Counter "\Hyper-V Hypervisor Root Virtual Processor(Root VP $procId)\% Total Run Time" -SampleInterval 1 -Continuous} -ArgumentList $i
-    $hostVPPerProcRuntimeJobs = $hostVPPerProcRuntimeJobs + $jobObj
-}
-
-#
-# Wait for all jobs to start
-#
-Log "Waiting for all jobs to start..."
-for ($i=$BaseCpuNumber; $i -le $MaxCpuNumber; $i++)
-{
-    $jobId = $hostVPPerProcRuntimeJobs[$i-$BaseCpuNumber].Id
-    Log "Waiting for VP[$i] counters to start..."
-    $value = Receive-Job -Id $jobId -Keep
-    while ($value.Count -lt 1)
-    {
-        $jobId = $hostVPPerProcRuntimeJobs[$i-$BaseCpuNumber].Id
-        $value = Receive-Job -Id $jobId -Keep
-        Sleep 1
-    }
-}
+    $value = Receive-Job $counterJob -Keep
+    Start-Sleep 1
+} 
 
 $waitTime = $WarmUpDurationInSeconds + $DurationInSeconds + $CoolDownDurationInSeconds
-Log "Wait for $waitTime seconds ($WarmUpDurationInSeconds seconds of warmup + $DurationInSeconds seconds of active measurement + $CoolDownDurationInSeconds seconds of cool down."
-Sleep $waitTime 
+Log "Counter collection started. Waiting for $waitTime seconds ($WarmUpDurationInSeconds seconds of warmup + $DurationInSeconds seconds of active measurement + $CoolDownDurationInSeconds seconds of cool down."
+Start-Sleep $waitTime
 
 
-#############################################
+#
 # Retrieve statistics
-#############################################
+#
 Log ""
 
+Stop-Job $counterJob
+$output = (((Receive-Job $counterJob).Readings | Out-String) -replace ":`n",": ") -split "`n|`r`n" | where {$_} # make -like work on output
+Remove-Job $counterJob
+
 Log "Calculating bytes/s in vswitch counters, $CoolDownDurationInSeconds seconds from end of run."
-$hostCounterRxBytesPerSecAvg = GetAverageFromGetCounterJob($hostCounterRxBytesPerSecJob.Id)
-$hostCounterRxBytesPerSecAvg = $hostCounterRxBytesPerSecAvg * 8;
+$hostCounterRxBytesPerSecAvg = Get-CounterAverage ($output -like "*($SwitchName)\Bytes Sent/sec*")
+$hostCounterRxBytesPerSecAvg *= 8
 
 Log "Calculating pkts/s in host switch port counters, $CoolDownDurationInSeconds seconds from end of run."
-$hostCounterRxPktsPerSecAvg = GetAverageFromGetCounterJob($hostCounterRxPktsPerSecJob.Id)
+$hostCounterRxPktsPerSecAvg = Get-CounterAverage ($output -like "*($SwitchName)\Packets Sent/sec*")
 
-#
 # Per proc host VP runtime
-#
 $hostVPRuntime = 0
 for ($i=$BaseCpuNumber; $i -le $MaxCpuNumber; $i++)
 {
     Log "Calculating VP utilization for VP $i, $CoolDownDurationInSeconds seconds from end of run ..."
-    $value = GetAverageFromGetCounterJob($hostVPPerProcRuntimeJobs[$i-$BaseCpuNumber].Id)
-    Log "`tHost utilization VP[$i]=$([math]::Round($value,2))"
+    $value = Get-CounterAverage ($output -like "*(Root VP $i)\% Total Run Time*")
+    Log "`tHost utilization VP[$i]=$([math]::Round($value, 2))"
 
     $hostVPRuntime += $value
 }
 $hostVPRuntime = $hostVPRuntime / ($MaxCpuNumber - $BaseCpuNumber + 1)
 
 
-#
 # Calculate path costs
-#
 $cpuCyclesPerSec = GetCpuClockSpeed
 $cpuCyclesPerSec = $cpuCyclesPerSec * 1000000
 $totalCyclesPerSec = ($MaxCpuNumber - $BaseCpuNumber + 1)  * $cpuCyclesPerSec
@@ -297,8 +233,8 @@ if ($hostCounterRxPktsPerSecAvg -ne 0)
     $pktPathCost = $totalCyclesPerSec / $hostCounterRxPktsPerSecAvg
 }
 
-
-Log "===============Results============================================"
+Log ""
+Log "==============================Results=============================="
 Log ""
 Log "CPU speed (cycles per second):                    $cpuCyclesPerSec"
 Log "VP Utilization:                                   $([math]::Round($hostVPRuntime,2))"


### PR DESCRIPTION
Instead of collecting each counter in its own Job, collect them all at once because it much faster.