### PR TITLE
Get-NetView: run some functions in background threads

### DIFF
--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -48,112 +48,121 @@ Param(
     [parameter(Mandatory=$false,HelpMessage="Skip check for Administrator privileges")] [Switch] $SkipAdminCheck
 )
 
-function ExecCommandText {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Command,
-        [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Output
-    )
+$ExecFunctions = {
+    # global vars
+    $columns   = 4096
+    $version   = "2017.08.23.0" # Version within date context
+    $timestamp = Get-Date -f yyyy.MM.dd_hh.mm.ss
 
-    # Mirror command execution context
-    $context = "$env:USERNAME @ $env:COMPUTERNAME:"
-    Write-Output $context | Out-File -Encoding ascii -Append $Output
+    function ExecCommandText {
+        [CmdletBinding()]
+        Param(
+            [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Command,
+            [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Output
+        )
 
-    # Mirror command to execute
-    $cmdMirror = "$(prompt)$Command"
-    Write-Output $cmdMirror | Out-File -Encoding ascii -Append $Output
-} # ExecCommandText()
+        # Mirror command execution context
+        $context = "$env:USERNAME @ $env:COMPUTERNAME:"
+        Write-Output $context | Out-File -Encoding ascii -Append $Output
 
-function ExecCommandPrivate {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Command,
-        [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Output
-    )
+        # Mirror command to execute
+        $cmdMirror = "$(prompt)$Command"
+        Write-Output $cmdMirror | Out-File -Encoding ascii -Append $Output
+    } # ExecCommandText()
 
-    ExecCommandText -Command ($Command) -Output $Output
+    function ExecCommandPrivate {
+        [CmdletBinding()]
+        Param(
+            [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Command,
+            [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Output
+        )
 
-    # Execute Command and redirect to file.  Useful so users know what to run!!!
-    Invoke-Expression $Command | Out-File -Encoding ascii -Append $Output
-} #ExecCommandPrivate()
+        ExecCommandText -Command ($Command) -Output $Output
 
-enum CommandStatus {
-    NotTested    # Indicates problem with TestCommand
-    Unavailable  # [Part of] the command doesn't exist
-    Failed       # An error prevented successful execution
-    Succeeded    # No errors or exceptions
-}
+        # Execute Command and redirect to file.  Useful so users know what to run!!!
+        Invoke-Expression $Command | Out-File -Encoding ascii -Append $Output
+    } #ExecCommandPrivate()
 
-function TestCommand {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Command
-    )
-
-    $result = [CommandStatus]::NotTested
-
-    Try {
-        # pre-execution cleanup
-        $error.clear()
-
-        # Instrument the validate command for silent output
-        #$tmp = "$Command -erroraction 'silentlycontinue' | Out-Null"
-        $tmp = "$Command | Out-Null"
-
-        # Redirect all error output to $null to encompass all possible errors
-        #Write-Host $tmp -ForegroundColor Yellow
-        Invoke-Expression $tmp 2> $null
-        if ($error -ne $null) {
-            # Some PS commands are incorrectly implemented in return code
-            # and require detecting SilentContinue
-            if (-not ($tmp -like '*SilentlyContinue*')) {
-                throw "Error: $error[0]"
-            }
-        }
-
-        # This is only reachable in success case
-        $result = [CommandStatus]::Succeeded
-    } Catch [Management.Automation.CommandNotFoundException] {
-        $result = [CommandStatus]::Unavailable
-    } Catch {
-        $result = [CommandStatus]::Failed
-    } Finally {
-        # post-execution cleanup to avoid false positives
-        $error.clear()
+    enum CommandStatus {
+        NotTested    # Indicates problem with TestCommand
+        Unavailable  # [Part of] the command doesn't exist
+        Failed       # An error prevented successful execution
+        Succeeded    # No errors or exceptions
     }
 
-    return $result
-} # TestCommand()
+    function TestCommand {
+        [CmdletBinding()]
+        Param(
+            [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Command
+        )
 
-# Powershell cmdlets have inconsistent implementations in command error handling. This function
-# performs a validation of the command prior to formal execution and will log any failures.
-function ExecCommand {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Command,
-        [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Output,
-        [parameter(Mandatory=$false)] [Switch] $Trusted
-    )
+        $result = [CommandStatus]::NotTested
 
-    if ($Trusted) {
-        # Skip command validation
-        Write-Host -ForegroundColor Cyan "$Command"
-        ExecCommandPrivate -Command $Command -Output $Output
-    } else {
-        $result = TestCommand -Command $Command
+        Try {
+            # pre-execution cleanup
+            $error.clear()
 
-        if ($result -eq [CommandStatus]::Succeeded) {
-            Write-Host -ForegroundColor Green "$Command"
+            # Instrument the validate command for silent output
+            #$tmp = "$Command -erroraction 'silentlycontinue' | Out-Null"
+            $tmp = "$Command | Out-Null"
+
+            # Redirect all error output to $null to encompass all possible errors
+            #Write-Host $tmp -ForegroundColor Yellow
+            Invoke-Expression $tmp 2> $null
+            if ($error -ne $null) {
+                # Some PS commands are incorrectly implemented in return code
+                # and require detecting SilentContinue
+                if (-not ($tmp -like '*SilentlyContinue*')) {
+                    throw "Error: $error[0]"
+                }
+            }
+
+            # This is only reachable in success case
+            $result = [CommandStatus]::Succeeded
+        } Catch [Management.Automation.CommandNotFoundException] {
+            $result = [CommandStatus]::Unavailable
+        } Catch {
+            $result = [CommandStatus]::Failed
+        } Finally {
+            # post-execution cleanup to avoid false positives
+            $error.clear()
+        }
+
+        return $result
+    } # TestCommand()
+
+    # Powershell cmdlets have inconsistent implementations in command error handling. This function
+    # performs a validation of the command prior to formal execution and will log any failures.
+    function ExecCommand {
+        [CmdletBinding()]
+        Param(
+            [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Command,
+            [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Output,
+            [parameter(Mandatory=$false)] [Switch] $Trusted
+        )
+
+        if ($Trusted) {
+            # Skip command validation
+            Write-Host -ForegroundColor Cyan "$Command"
             ExecCommandPrivate -Command $Command -Output $Output
         } else {
-            Write-Warning "[Command $result] $Command"
+            $result = TestCommand -Command $Command
 
-            Write-Output "$Command" | Out-File -Encoding ascii -Append $Output
-            Write-Output "[Command $result]" | Out-File -Encoding ascii -Append $Output
-            Write-Output "`n`n" | Out-File -Encoding ascii -Append $Output
+            if ($result -eq [CommandStatus]::Succeeded) {
+                Write-Host -ForegroundColor Green "$Command"
+                ExecCommandPrivate -Command $Command -Output $out
+            } else {
+                Write-Warning "[Command $result] $Command"
+
+                Write-Output "$Command" | Out-File -Encoding ascii -Append $out
+                Write-Output "[Command $result]" | Out-File -Encoding ascii -Append $out
+                Write-Output "`n`n" | Out-File -Encoding ascii -Append $out
+            }
         }
-    }
-} # ExecCommand()
+    } # ExecCommand()
+} # $ExecFunctions
+
+. $ExecFunctions # import into script context
 
 function NetIpNicWorker {
     [CmdletBinding()]
@@ -2102,6 +2111,55 @@ function Completion {
     Write-Host "Files:   $((Get-ChildItem $Src -File -Recurse | Measure-Object).Count)"
 } # Completion()
 
+function Start-Thread() {
+    [CmdletBinding()]
+    Param(
+        [parameter(Mandatory=$true)] [ScriptBlock] $ScriptBlock,
+        [parameter(Mandatory=$false)] [Hashtable] $Params = @{}
+    )
+
+    $ps = [PowerShell]::Create()
+
+    $ps.Runspace = [RunspaceFactory]::CreateRunspace()
+    $ps.Runspace.Open()
+    $null = $ps.AddScript($ExecFunctions) # import into thread context
+    $null = $ps.AddScript($ScriptBlock).AddParameters($Params)
+
+    $async = $ps.BeginInvoke()
+
+    return @{Name=$ScriptBlock.Ast.Name; AsyncResult=$async; PowerShell=$ps}
+} # Start-Thread()
+
+function Remove-Thread() {
+    [CmdletBinding()]
+    Param(
+        [parameter(Mandatory=$true)] [Hashtable] $Thread
+    )
+    Write-Host "Stopping thread $($Thread.Name)..."
+    $Thread.PowerShell.Stop()
+    $Thread.PowerShell.Dispose()
+    $Thread.PowerShell.Runspace.Close()
+}
+
+function StreamThread() {
+    [CmdletBinding()]
+    Param(
+        [parameter(Mandatory=$true)] [Hashtable] $Thread
+    )
+
+    Write-Host "`nOn thread: $($Thread.Name)"
+    Write-Host "----------------------------------------------"
+
+    do {
+        Start-Sleep -Milliseconds 50
+        # TODO output errors/other streams
+        $Thread.PowerShell.Streams.Information | Out-Host
+        $Thread.PowerShell.Streams.Information.Clear()
+    } until ($Thread.AsyncResult.IsCompleted)
+
+    $Thread.PowerShell.EndInvoke($Thread.AsyncResult)
+} # StreamThread()
+
 function Worker {
     [CmdletBinding()]
     Param(
@@ -2109,37 +2167,42 @@ function Worker {
         [parameter(Mandatory=$false)] [Bool] $SkipAdminCheck
     )
 
-    $columns   = 4096
-    $version   = "2017.09.27.0" # Version within date context
-    $timestamp = Get-Date -f yyyy.MM.dd_hh.mm.ss
-
     # Input Validation
     CheckAdminPrivileges $SkipAdminCheck
     $workDir = NormalizeWorkDir -OutputDirectory $OutputDirectory
 
     EnvSetup          -OutDir $workDir
-
-    # Start Run
     Clear-Host
 
-    Metadata          -OutDir $workDir -Params $PSBoundParameters
-    Environment       -OutDir $workDir
-    NetworkSummary    -OutDir $workDir
+    # Start Run
+    try {
+        $threads = if ($true) {
+            Start-Thread ${function:ServicesDrivers} -Params @{OutDir=$workDir}
+            Start-Thread ${function:NetshTrace} -Params @{OutDir=$workDir}
+            Start-Thread ${function:Counters} -Params @{OutDir=$workDir}
+        }
 
-    HwErrorReport     -OutDir $workDir
-    LogsReport        -OutDir $workDir
+        Metadata          -OutDir $workDir -Params $PSBoundParameters
+        Environment       -OutDir $workDir
+        NetworkSummary    -OutDir $workDir
 
-    NetSetupDetail    -OutDir $workDir
-    VMSwitchDetail    -OutDir $workDir
-    LbfoDetail        -OutDir $workDir
-    NativeNicDetail   -OutDir $workDir
-    NicVendor         -OutDir $workDir
-    QosDetail         -OutDir $workDir
-    SMBDetail         -OutDir $workDir
-    NetIp             -OutDir $workDir
-    ServicesDrivers   -OutDir $workDir
-    NetshTrace        -OutDir $workDir
-    Counters          -OutDir $workDir
+        HwErrorReport     -OutDir $workDir
+        LogsReport        -OutDir $workDir
+
+        NetSetupDetail    -OutDir $workDir
+        VMSwitchDetail    -OutDir $workDir
+        LbfoDetail        -OutDir $workDir
+        NativeNicDetail   -OutDir $workDir
+        NicVendor         -OutDir $workDir
+        QosDetail         -OutDir $workDir
+        SMBDetail         -OutDir $workDir
+        NetIp             -OutDir $workDir
+
+        $threads | foreach {StreamThread $_}
+    } finally {
+        Write-Host "Removing background threads..."
+        $threads | foreach {Remove-Thread $_}
+    }
 
     Completion -Src $workDir -OutZip "$workDir-$timestamp.zip"
 } # Worker()

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -51,7 +51,7 @@ Param(
 $ExecFunctions = {
     # global vars
     $columns   = 4096
-    $version   = "2017.08.23.0" # Version within date context
+    $version   = "2017.11.03.0" # Version within date context
     $timestamp = Get-Date -f yyyy.MM.dd_hh.mm.ss
 
     function ExecCommandText {
@@ -1117,8 +1117,8 @@ function VMNetworkAdapterWorker {
     )
 
     # Normalize Names
-    $dir  = $OutDir
     $name = $VMNicName
+    $dir  = $OutDir
 
     $file = "Get-VMNetworkAdapter.txt"
     $out  = (Join-Path -Path $dir -ChildPath $file)
@@ -1335,7 +1335,7 @@ function VMSwitchWorker {
 
     # Normalize Names
     $name = $VMSwitchName
-    $out  = $OutDir
+    $dir  = $OutDir
 
     $file = "Get-VMSwitch.txt"
     $out  = (Join-Path -Path $dir -ChildPath $file)


### PR DESCRIPTION
## Overview
Use Runspaces to run the 3 slowest functions in background threads. For me this, this halved the execution time:
- 2m 20s → 1m 10s (-50%) on client
- 9m 48s → 4m 53s (-50.17%) on server

On systems with a lot of vSwitches, etc it's expected that the time improvement would be much less.

## Notes

- Closing the PowerShell window will just terminate any background threads.
- Ctrl-C works, but may take some time to stop all the background threads.