### PR TITLE
Get-NetView: address feedback and other small improvements

### DIFF
--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -2147,12 +2147,14 @@ function CreateZip {
 function Completion {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $Src,
-        [parameter(Mandatory=$true)] [String] $OutZip
+        [parameter(Mandatory=$true)] [String] $Src
     )
 
+    $timestamp = $start | Get-Date -f yyyy.MM.dd_hh.mm.ss
+
     # Zip output folder
-    CreateZip -Src $Src -Out $OutZip
+    $outzip = "$Src-$timestamp.zip"
+    CreateZip -Src $Src -Out $outzip
 
     $dirs = (Get-ChildItem $Src -Recurse | Measure-Object -Property length -Sum) # out folder size
     $hash = (Get-FileHash -Path $MyInvocation.PSCommandPath -Algorithm "SHA256").Hash # script hash
@@ -2165,30 +2167,36 @@ function Completion {
     Write-Host "Version: $version"
     Write-Host "SHA256:  $(if ($hash) {$hash} else {"N/A"})"
     Write-Host ""
-    Write-Host $OutZip
-    Write-Host "Size:    $("{0:N2} MB" -f ((Get-Item $OutZip).Length / 1MB))"
+    Write-Host $outzip
+    Write-Host "Size:    $("{0:N2} MB" -f ((Get-Item $outzip).Length / 1MB))"
     Write-Host ""
     Write-Host $Src
     Write-Host "Size:    $("{0:N2} MB" -f ($dirs.sum / 1MB))"
     Write-Host "Dirs:    $((Get-ChildItem $Src -Directory -Recurse | Measure-Object).Count)"
     Write-Host "Files:   $((Get-ChildItem $Src -File -Recurse | Measure-Object).Count)"
+    Write-Host ""
+    Write-Host "Execution Time:"
+    Write-Host "---------------"
+    $delta = (Get-Date) - $Start
+    Write-Host "$($delta.Minutes) Min $($delta.Seconds) Sec"
+    Write-Host "`n"
 } # Completion()
 
-function Worker {
+function Get-NetView {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$false)] [String] $OutputDirectory,
-        [parameter(Mandatory=$false)] [Bool] $SkipAdminCheck
+        [parameter(Mandatory=$false,HelpMessage="Complete Path to the output directory")] [String] $OutputDirectory,
+        [parameter(Mandatory=$false,HelpMessage="Skip check for Administrator privileges")] [Switch] $SkipAdminCheck
     )
 
+    $start = Get-Date
     $version = "2017.11.06.0" # Version within date context
-    $timestamp = Get-Date -f yyyy.MM.dd_hh.mm.ss
 
     # Input Validation
     CheckAdminPrivileges $SkipAdminCheck
     $workDir = NormalizeWorkDir -OutputDirectory $OutputDirectory
 
-    EnvSetup          -OutDir $workDir
+    EnvSetup $workDir
     Clear-Host
 
     # Start Run
@@ -2221,16 +2229,5 @@ function Worker {
         $threads | foreach {Remove-Thread $_}
     }
 
-    Completion -Src $workDir -OutZip "$workDir-$timestamp.zip"
-} # Worker()
-
-function Get-NetView {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$false,HelpMessage="Complete Path to the output directory")] [String] $OutputDirectory,
-        [parameter(Mandatory=$false,HelpMessage="Skip check for Administrator privileges")] [Switch] $SkipAdminCheck
-    )
-
-    # If it moves, measure it.  We should know how long this takes...
-    Measure-Command {Worker @PSBoundParameters} | select @{n="Execution Time:";e={$_.Minutes,"Min",$_.Seconds,"Sec" -join " "}}
+    Completion -Src $workDir
 } Get-NetView @PSBoundParameters # Entry Point

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -150,13 +150,13 @@ $ExecFunctions = {
 
             if ($result -eq [CommandStatus]::Succeeded) {
                 Write-Host -ForegroundColor Green "$Command"
-                ExecCommandPrivate -Command $Command -Output $out
+                ExecCommandPrivate -Command $Command -Output $Output
             } else {
                 Write-Warning "[Command $result] $Command"
 
-                Write-Output "$Command" | Out-File -Encoding ascii -Append $out
-                Write-Output "[Command $result]" | Out-File -Encoding ascii -Append $out
-                Write-Output "`n`n" | Out-File -Encoding ascii -Append $out
+                Write-Output "$Command" | Out-File -Encoding ascii -Append $Output
+                Write-Output "[Command $result]" | Out-File -Encoding ascii -Append $Output
+                Write-Output "`n`n" | Out-File -Encoding ascii -Append $Output
             }
         }
     } # ExecCommand()

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -44,8 +44,12 @@
     https://github.com/Microsoft/SDN
 #>
 Param(
-    [parameter(Mandatory=$false,HelpMessage="Path to the output directory")] [String] $OutputDirectory,
-    [parameter(Mandatory=$false,HelpMessage="Skip check for Administrator privileges")] [Switch] $SkipAdminCheck
+    [parameter(Mandatory=$false,HelpMessage="Complete Path to the output directory")]
+    [ValidateScript({Test-Path $_ -PathType Container})]
+    [String] $OutputDirectory,
+
+    [parameter(Mandatory=$false,HelpMessage="Skip check for Administrator privileges")]
+    [Switch] $SkipAdminCheck
 )
 
 #
@@ -2185,8 +2189,12 @@ function Completion {
 function Get-NetView {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$false,HelpMessage="Complete Path to the output directory")] [String] $OutputDirectory,
-        [parameter(Mandatory=$false,HelpMessage="Skip check for Administrator privileges")] [Switch] $SkipAdminCheck
+        [parameter(Mandatory=$false,HelpMessage="Complete Path to the output directory")]
+        [ValidateScript({Test-Path $_ -PathType Container})]
+        [String] $OutputDirectory,
+
+        [parameter(Mandatory=$false,HelpMessage="Skip check for Administrator privileges")]
+        [Switch] $SkipAdminCheck
     )
 
     $start = Get-Date

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -55,8 +55,6 @@ Param(
 $ExecFunctions = {
     # Global vars
     $columns   = 4096
-    $version   = "2017.11.03.0" # Version within date context
-    $timestamp = Get-Date -f yyyy.MM.dd_hh.mm.ss
 
     function ExecCommandText {
         [CmdletBinding()]
@@ -2182,6 +2180,9 @@ function Worker {
         [parameter(Mandatory=$false)] [String] $OutputDirectory,
         [parameter(Mandatory=$false)] [Bool] $SkipAdminCheck
     )
+
+    $version = "2017.11.06.0" # Version within date context
+    $timestamp = Get-Date -f yyyy.MM.dd_hh.mm.ss
 
     # Input Validation
     CheckAdminPrivileges $SkipAdminCheck

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -48,8 +48,12 @@ Param(
     [parameter(Mandatory=$false,HelpMessage="Skip check for Administrator privileges")] [Switch] $SkipAdminCheck
 )
 
+#
+# Common Functions
+#
+
 $ExecFunctions = {
-    # global vars
+    # Global vars
     $columns   = 4096
     $version   = "2017.11.03.0" # Version within date context
     $timestamp = Get-Date -f yyyy.MM.dd_hh.mm.ss
@@ -163,6 +167,59 @@ $ExecFunctions = {
 } # $ExecFunctions
 
 . $ExecFunctions # import into script context
+
+function Start-Thread() {
+    [CmdletBinding()]
+    Param(
+        [parameter(Mandatory=$true)] [ScriptBlock] $ScriptBlock,
+        [parameter(Mandatory=$false)] [Hashtable] $Params = @{}
+    )
+
+    $ps = [PowerShell]::Create()
+
+    $ps.Runspace = [RunspaceFactory]::CreateRunspace()
+    $ps.Runspace.Open()
+    $null = $ps.AddScript($ExecFunctions) # import into thread context
+    $null = $ps.AddScript($ScriptBlock).AddParameters($Params)
+
+    $async = $ps.BeginInvoke()
+
+    return @{Name=$ScriptBlock.Ast.Name; AsyncResult=$async; PowerShell=$ps}
+} # Start-Thread()
+
+function Remove-Thread() {
+    [CmdletBinding()]
+    Param(
+        [parameter(Mandatory=$true)] [Hashtable] $Thread
+    )
+    Write-Host "Stopping thread $($Thread.Name)..."
+    $Thread.PowerShell.Stop()
+    $Thread.PowerShell.Dispose()
+    $Thread.PowerShell.Runspace.Close()
+}
+
+function StreamThread() {
+    [CmdletBinding()]
+    Param(
+        [parameter(Mandatory=$true)] [Hashtable] $Thread
+    )
+
+    Write-Host "`nOn thread: $($Thread.Name)"
+    Write-Host "----------------------------------------------"
+
+    do {
+        Start-Sleep -Milliseconds 50
+        # TODO output errors/other streams
+        $Thread.PowerShell.Streams.Information | Out-Host
+        $Thread.PowerShell.Streams.Information.Clear()
+    } until ($Thread.AsyncResult.IsCompleted)
+
+    $Thread.PowerShell.EndInvoke($Thread.AsyncResult)
+} # StreamThread()
+
+#
+# Data Collection Functions
+#
 
 function NetIpNicWorker {
     [CmdletBinding()]
@@ -1993,6 +2050,10 @@ function HostInfo {
     #>
 } # HostInfo()
 
+#
+# Setup & Validation Functions
+#
+
 function CheckAdminPrivileges {
     [CmdletBinding()]
     Param(
@@ -2081,6 +2142,10 @@ function CreateZip {
     [io.compression.zipfile]::CreateFromDirectory($Src, $Out)
 } # CreateZip()
 
+#
+# Main Program
+#
+
 function Completion {
     [CmdletBinding()]
     Param(
@@ -2110,55 +2175,6 @@ function Completion {
     Write-Host "Dirs:    $((Get-ChildItem $Src -Directory -Recurse | Measure-Object).Count)"
     Write-Host "Files:   $((Get-ChildItem $Src -File -Recurse | Measure-Object).Count)"
 } # Completion()
-
-function Start-Thread() {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [ScriptBlock] $ScriptBlock,
-        [parameter(Mandatory=$false)] [Hashtable] $Params = @{}
-    )
-
-    $ps = [PowerShell]::Create()
-
-    $ps.Runspace = [RunspaceFactory]::CreateRunspace()
-    $ps.Runspace.Open()
-    $null = $ps.AddScript($ExecFunctions) # import into thread context
-    $null = $ps.AddScript($ScriptBlock).AddParameters($Params)
-
-    $async = $ps.BeginInvoke()
-
-    return @{Name=$ScriptBlock.Ast.Name; AsyncResult=$async; PowerShell=$ps}
-} # Start-Thread()
-
-function Remove-Thread() {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [Hashtable] $Thread
-    )
-    Write-Host "Stopping thread $($Thread.Name)..."
-    $Thread.PowerShell.Stop()
-    $Thread.PowerShell.Dispose()
-    $Thread.PowerShell.Runspace.Close()
-}
-
-function StreamThread() {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [Hashtable] $Thread
-    )
-
-    Write-Host "`nOn thread: $($Thread.Name)"
-    Write-Host "----------------------------------------------"
-
-    do {
-        Start-Sleep -Milliseconds 50
-        # TODO output errors/other streams
-        $Thread.PowerShell.Streams.Information | Out-Host
-        $Thread.PowerShell.Streams.Information.Clear()
-    } until ($Thread.AsyncResult.IsCompleted)
-
-    $Thread.PowerShell.EndInvoke($Thread.AsyncResult)
-} # StreamThread()
 
 function Worker {
     [CmdletBinding()]


### PR DESCRIPTION
Commits are self explanatory.

In regards to `add section headers` the "Data Collection Functions" header needs to be broken up into smaller ones. However, that might require moving functions around, which would be too complicated for this PR.

Commit `use Get-Date to output execution time` has a noisier diff, so the summary is:
1. Removed Measure-Command use.
2. Combined now redundant Worker and Get-NetView together.
3. Use Get-Date math to output execution time in Completion.
4. Move -OutZip inside Completion, because it is prettier.
