### PR TITLE
Get-NetView: Set Global ErrorActionPreferance to "Stop" in TestCommand

### DIFF
--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -2438,7 +2438,7 @@ function Get-NetView {
     )
 
     $start = Get-Date
-    $version = "2017.12.08.0" # Version within date context
+    $version = "2017.12.20.0" # Version within date context
 
     # Input Validation
     CheckAdminPrivileges $SkipAdminCheck

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -112,37 +112,42 @@ $ExecFunctions = {
             [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Command
         )
 
+        $oldGlobalErrorActionPreference = $Global:ErrorActionPreference
         $result  = [CommandStatus]::NotTested
         $failure = $null
 
-        Try {
+        try {
             # pre-execution cleanup
             $error.clear()
 
             # Instrument the validate command for silent output
-            #$tmp = "$Command -erroraction 'silentlycontinue' | Out-Null"
+            #$tmp = "$Command -ErrorAction 'SilentlyContinue' | Out-Null"
             $tmp = "$Command | Out-Null"
+
+            # ErrorAction MUST be Stop for try catch to work.
+            $Global:ErrorActionPreference = "Stop"
 
             # Redirect all error output to $null to encompass all possible errors
             #Write-Host $tmp -ForegroundColor Yellow
             Invoke-Expression $tmp 2> $null
             if ($error -ne $null) {
                 # Some PS commands are incorrectly implemented in return code
-                # and require detecting SilentContinue
-                if (-not ($tmp -like '*SilentlyContinue*')) {
+                # and require detecting SilentlyContinue
+                if (-not ($tmp -like "*SilentlyContinue*")) {
                     throw $error[0]
                 }
             }
 
             # This is only reachable in success case
             $result = [CommandStatus]::Succeeded
-        } Catch [Management.Automation.CommandNotFoundException] {
+        } catch [Management.Automation.CommandNotFoundException] {
             $result = [CommandStatus]::Unavailable
-        } Catch {
+        } catch {
             $result  = [CommandStatus]::Failed
             $failure = $error[0] | Out-String
-        } Finally {
+        } finally {
             # post-execution cleanup to avoid false positives
+            $Global:ErrorActionPreference = $oldGlobalErrorActionPreference
             $error.clear()
         }
 


### PR DESCRIPTION
This should be a nonfunctional change for the .ps1 version, because the ErrorActionPreference is already (effectively, not literally) "Stop". However, in the .psm1 version of the script, ErrorActionPreference needs to be set explicitly to "Stop" for TestCommand to work.