### PR TITLE
Fix typo in start-kubelet.ps1

### DIFF
--- a/Kubernetes/windows/start-kubelet.ps1
+++ b/Kubernetes/windows/start-kubelet.ps1
@@ -193,7 +193,7 @@ if (-not $podCidrDiscovered)
 
 # startup the service
 ipmo C:\k\hns.psm1
-$hnsNetwork = Get-HnsNetworks | ? Name -EQ $NetworkMode.ToLower()
+$hnsNetwork = Get-HnsNetwork | ? Name -EQ $NetworkMode.ToLower()
 
 if (!$hnsNetwork)
 {


### PR DESCRIPTION
The function "Get-HnsNetworks" does not exist... this should be "Get-HnsNetwork".