### PR TITLE
Fix missing Library information

### DIFF
--- a/VMM/VMM SDN Express/VMMExpress.ps1
+++ b/VMM/VMM SDN Express/VMMExpress.ps1
@@ -300,8 +300,10 @@ function importServiceTemplate
 	Set-SCPackageMapping -PackageMapping $mapping -TargetObject $resource
 	
 	#MAP NCsetup.cr
-	$VMMLibrary = $node.VMMLibrary
+	#$VMMLibrary = $node.VMMLibrary
+	$VMMLibrary = Get-SCLibraryShare | where LibraryServer -eq $resource.LibraryServer | where Path -eq $resource.Directory
 	#$VMMLibrary = Get-SCLibraryShare
+
 	$NCsetupPath = $serviceTemplateLocation + "NCSetup.cr\"
 	Import-SCLibraryPhysicalResource -SourcePath $NCsetupPath -SharePath $VMMLibrary -OverwriteExistingFiles
 	


### PR DESCRIPTION
The configuration does not contain contain any VMM Library information, and thus $node.VMMLibrary is empty making "Import-SCLibraryPhysicalResource" fail. 
Changing script to import resources into the same Library as VHD/VHDX files are in rather than add the option in configuration file. 
It's possible this problem only happens when there is more than one library in VMM.