### PR TITLE
! Missing download in the flannel start script

### DIFF
--- a/Kubernetes/flannel/l2bridge/start.ps1
+++ b/Kubernetes/flannel/l2bridge/start.ps1
@@ -60,6 +60,7 @@ function DownloadWindowsKubernetesScripts()
     DownloadFileOverHttps -Url https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/InstallImages.ps1 -DestinationPath $BaseDir\InstallImages.ps1
     DownloadFileOverHttps -Url https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/Dockerfile -DestinationPath $BaseDir\Dockerfile
     DownloadFileOverHttps -Url https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/stop.ps1 -DestinationPath $BaseDir\stop.ps1
+    DownloadFileOverHttps -Url https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/pause.ps1 -DestinationPath $BaseDir\pause.ps1
     DownloadFileOverHttps -Url https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/start-kubelet.ps1 -DestinationPath $BaseDir\start-Kubelet.ps1
     DownloadFileOverHttps -Url https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/start-kubeproxy.ps1 -DestinationPath $BaseDir\start-Kubeproxy.ps1
 }

--- a/Kubernetes/flannel/overlay/start.ps1
+++ b/Kubernetes/flannel/overlay/start.ps1
@@ -60,6 +60,7 @@ function DownloadWindowsKubernetesScripts()
     DownloadFileOverHttps -Url https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/InstallImages.ps1 -DestinationPath $BaseDir\InstallImages.ps1
     DownloadFileOverHttps -Url https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/Dockerfile -DestinationPath $BaseDir\Dockerfile
     DownloadFileOverHttps -Url https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/Stop.ps1 -DestinationPath $BaseDir\Stop.ps1
+    DownloadFileOverHttps -Url https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/pause.ps1 -DestinationPath $BaseDir\Stop.ps1
     DownloadFileOverHttps -Url https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/overlay/start-kubelet.ps1 -DestinationPath $BaseDir\start-Kubelet.ps1
     DownloadFileOverHttps -Url https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/start-kubeproxy.ps1 -DestinationPath $BaseDir\start-Kubeproxy.ps1
 }


### PR DESCRIPTION
Seems like the l2bridge flannel start script forgets to download the `pause.ps1` script. It's used in the dockerfile, so without it the container build call will fail