### PR TITLE
Kubelet pause image - use cmd/bat instead of powershell for lower memory usage

### DIFF
--- a/Kubernetes/windows/Dockerfile
+++ b/Kubernetes/windows/Dockerfile
@@ -1,5 +1,5 @@
 FROM microsoft/windowsservercore
 
-ADD pause.ps1 /pause/pause.ps1
+ADD pause.bat /pause/pause.bat
 
-CMD powershell /pause/pause.ps1
+CMD /pause/pause.bat

--- a/Kubernetes/windows/pause.bat
+++ b/Kubernetes/windows/pause.bat
@@ -1,0 +1,5 @@
+@echo off
+
+:loop
+timeout /t 99999 /nobreak > NUL
+goto loop

--- a/Kubernetes/windows/pause.ps1
+++ b/Kubernetes/windows/pause.ps1
@@ -1,4 +1,0 @@
-while($true)
-{
-    Start-Sleep -Seconds 60
-}


### PR DESCRIPTION
Use a batch script for the kubelet pause image instead of powershell for much lower memory usage per pod