### PR TITLE
Refining Flannel + Host-gw instructions

### DIFF
--- a/Kubernetes/flannel/l2bridge/ReadMe.md
+++ b/Kubernetes/flannel/l2bridge/ReadMe.md
@@ -1,22 +1,32 @@
-# How to deploy Kuberbetes on Windows with Flannel + HostGW
+# How to deploy Kubernetes on Windows with Flannel + HostGW
 
 ## Prerequisites
-* You have a Kubernetes Master that was successfully setup using Flannel. For example, using [kubeadm](https://kubernetes.io/docs/tasks/tools/install-kubeadm/).
+* You have a Kubernetes Master that was successfully setup using Flannel *with host-gateway as the network backend*. This can be done using [kubeadm](https://kubernetes.io/docs/tasks/tools/install-kubeadm/), for example.
+  * Kube-Proxy and Flannel DaemonSets are scheduled to only target Linux nodes. You can do this by applying this [node-selector](./manifests/node-selector-patch.yml).
+* You are using Windows Server, version 1709 or above.
 
-## Instructions 
-#### 1. Create the Kubernetes for Windows directory
+## Instructions
+
+#### 1. Install Docker
+```
+Install-Module -Name DockerMsftProvider -Repository PSGallery -Force
+Install-Package -Name Docker -ProviderName DockerMsftProvider
+Restart-Computer -Force
+```
+
+#### 2. Create the Kubernetes for Windows directory
 ```
 mkdir C:\k
 ```
 
-#### 2. Download the contents of [l2bridge directory](.) into `C:\k` and do the following:
-  * Donwload Kubernetes Windows binaries (kubelet.exe, kubectl.exe, kube-proxy.exe) into `C:\k`
+#### 3. Download the contents of [l2bridge directory](.) into `C:\k` and do the following:
+  * Download Kubernetes Windows binaries (kubelet.exe, kubectl.exe, kube-proxy.exe) into `C:\k`
     * See [Kubernetes release notes](https://github.com/kubernetes/kubernetes/releases/) for newest version
   * Copy Kubeconfig file `$HOME/.kube/config` or `/etc/kubernetes/admin.conf` from Kubernetes Master and save as `config` into `C:\k`
   * Ensure the cluster CIDR (e.g. "10.244.0.0/16") is correct in:
     * [net-conf.json](./net-conf.json)
 
-#### 3. Run the following inside `C:\k` to join the Windows worker:
+#### 4. Join the Kubernetes cluster:
 ```
 .\start.ps1 -ManagementIP <Windows_Worker_Mgmt_IP> -ClusterCIDR <ClusterCIDR> -ServiceCIDR <SvcCIDR> -KubeDnsServiceIP <KubeDNSIP>
 ```
@@ -27,6 +37,7 @@ Where:
   * `ServiceCIDR`: The address range used by [Kubernetes services](https://kubernetes.io/docs/concepts/services-networking/service/).
   * `KubeDnsServiceIP`: The DNS service VIP used by [kube-dns](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/).
 
+#### 5. Deploy an [example Windows service](./manifests/simpleweb.yml)
 
 ## Temp Binaries that will be removed soon
 There are several pending PRs, because of which the bins are published here

--- a/Kubernetes/flannel/l2bridge/ReadMe.md
+++ b/Kubernetes/flannel/l2bridge/ReadMe.md
@@ -1,7 +1,7 @@
 # How to deploy Kubernetes on Windows with Flannel + HostGW
 
 ## Prerequisites
-* You have a Kubernetes Master that was successfully setup using Flannel *with host-gateway as the network backend*. This can be done using [kubeadm](https://kubernetes.io/docs/tasks/tools/install-kubeadm/), for example.
+* You have a Kubernetes Master that was successfully setup using Flannel *with host-gateway as the network backend*. This can be done using [kubeadm](https://kubernetes.io/docs/tasks/tools/install-kubeadm/), or our [Kubernetes master from scratch](https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/creating-a-linux-master) instructions, for example.
   * Kube-Proxy and Flannel DaemonSets are scheduled to only target Linux nodes. You can do this by applying this [node-selector](./manifests/node-selector-patch.yml).
 * You are using Windows Server, version 1709 or above.
 
@@ -37,7 +37,7 @@ Where:
   * `ServiceCIDR`: The address range used by [Kubernetes services](https://kubernetes.io/docs/concepts/services-networking/service/).
   * `KubeDnsServiceIP`: The DNS service VIP used by [kube-dns](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/).
 
-#### 5. Deploy an [example Windows service](./manifests/simpleweb.yml)
+#### 5. Deploy an [example Windows service](./manifests/simpleweb.yml) (make sure container image matches host OS)
 
 ## Temp Binaries that will be removed soon
 There are several pending PRs, because of which the bins are published here

--- a/Kubernetes/flannel/l2bridge/ReadMe.md
+++ b/Kubernetes/flannel/l2bridge/ReadMe.md
@@ -1,12 +1,34 @@
 # How to deploy Kuberbetes on Windows with Flannel + HostGW
-* Download Kubelet.exe, Kubectl.exe, Kube-Proxy.exe to c:\k
-* Copy Kubeconfig from Linux master to c:\k
-* Download the following file(s) to c:\k
-    [start.ps1](https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/start.ps1)     
-* run powershell c:\k\start.ps1 -ManagementIP <IPAddressOfTheCurrentNode>
+
+## Prerequisites
+* You have a Kubernetes Master that was successfully setup using Flannel. For example, using [kubeadm](https://kubernetes.io/docs/tasks/tools/install-kubeadm/).
+
+## Instructions 
+1. Create the Kubernetes for Windows directory
+```
+PS C:> mkdir C:\k
+```
+
+2. Download the contents of [l2bridge directory](.) into `C:\k` and do the following:
+  * Donwload Kubernetes Windows binaries (kubelet.exe, kubectl.exe, kube-proxy.exe) into `C:\k`
+    * See [Kubernetes release notes](https://github.com/kubernetes/kubernetes/releases/) for newest version
+  * Copy Kubeconfig file `$HOME/.kube/config` or `/etc/kubernetes/admin.conf` from Kubernetes Master and save as `config` into `C:\k`
+  * Ensure the cluster CIDR (e.g. "10.244.0.0/16") is correct in:
+    * [net-conf.json](./net-conf.json)
+
+3. Run the following inside `C:\k` to join the Windows worker:
+```
+PS C:\k> .\start.ps1 -ManagementIP <Windows_Worker_Mgmt_IP> -ClusterCIDR <ClusterCIDR> -ServiceCIDR <SvcCIDR> -KubeDnsServiceIP <KubeDNSIP>
+```
+
+Where:
+  * `ManagementIP`: The IP address of your Windows container host.
+  * `ClusterCIDR`: The address range used by [Kubernetes pods](https://kubernetes.io/docs/concepts/workloads/pods/pod/).
+  * `ServiceCIDR`: The address range used by [Kubernetes services](https://kubernetes.io/docs/concepts/services-networking/service/).
+  * `KubeDnsServiceIP`: The DNS service VIP used by [kube-dns](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/).
 
 
-# Temp Binaries that will be removed soon
+## Temp Binaries that will be removed soon
 There are several pending PRs, because of which the bins are published here
 [host-gw: add windows support](https://github.com/coreos/flannel/pull/921)
 * flanned.exe - 

--- a/Kubernetes/flannel/l2bridge/ReadMe.md
+++ b/Kubernetes/flannel/l2bridge/ReadMe.md
@@ -4,21 +4,21 @@
 * You have a Kubernetes Master that was successfully setup using Flannel. For example, using [kubeadm](https://kubernetes.io/docs/tasks/tools/install-kubeadm/).
 
 ## Instructions 
-1. Create the Kubernetes for Windows directory
+#### 1. Create the Kubernetes for Windows directory
 ```
-PS C:> mkdir C:\k
+mkdir C:\k
 ```
 
-2. Download the contents of [l2bridge directory](.) into `C:\k` and do the following:
+#### 2. Download the contents of [l2bridge directory](.) into `C:\k` and do the following:
   * Donwload Kubernetes Windows binaries (kubelet.exe, kubectl.exe, kube-proxy.exe) into `C:\k`
     * See [Kubernetes release notes](https://github.com/kubernetes/kubernetes/releases/) for newest version
   * Copy Kubeconfig file `$HOME/.kube/config` or `/etc/kubernetes/admin.conf` from Kubernetes Master and save as `config` into `C:\k`
   * Ensure the cluster CIDR (e.g. "10.244.0.0/16") is correct in:
     * [net-conf.json](./net-conf.json)
 
-3. Run the following inside `C:\k` to join the Windows worker:
+#### 3. Run the following inside `C:\k` to join the Windows worker:
 ```
-PS C:\k> .\start.ps1 -ManagementIP <Windows_Worker_Mgmt_IP> -ClusterCIDR <ClusterCIDR> -ServiceCIDR <SvcCIDR> -KubeDnsServiceIP <KubeDNSIP>
+.\start.ps1 -ManagementIP <Windows_Worker_Mgmt_IP> -ClusterCIDR <ClusterCIDR> -ServiceCIDR <SvcCIDR> -KubeDnsServiceIP <KubeDNSIP>
 ```
 
 Where:

--- a/Kubernetes/flannel/l2bridge/cni/config/cni.conf
+++ b/Kubernetes/flannel/l2bridge/cni/config/cni.conf
@@ -6,7 +6,7 @@
                      "type":  "l2bridge",
                      "dns":  {
                                  "Nameservers":  [
-                                                     "11.0.0.10"
+                                                     "10.96.0.10"
                                                  ],
                                  "Search":  [
                                                 "svc.cluster.local"
@@ -18,9 +18,9 @@
                                                 "Value":  {
                                                               "Type":  "OutBoundNAT",
                                                               "ExceptionList":  [
-                                                                                    "192.168.0.0/16",
-                                                                                    "11.0.0.0/8",
-                                                                                    "10.124.24.0/23"
+                                                                                    "10.244.0.0/16",
+                                                                                    "10.96.0.0/12",
+                                                                                    "10.127.130.0/24"
                                                                                 ]
                                                           }
                                             },
@@ -28,7 +28,7 @@
                                                 "Name":  "EndpointPolicy",
                                                 "Value":  {
                                                               "Type":  "ROUTE",
-                                                              "DestinationPrefix":  "11.0.0.0/8",
+                                                              "DestinationPrefix":  "10.96.0.0/12",
                                                               "NeedEncap":  true
                                                           }
                                             },
@@ -36,7 +36,7 @@
                                                 "Name":  "EndpointPolicy",
                                                 "Value":  {
                                                               "Type":  "ROUTE",
-                                                              "DestinationPrefix":  "10.124.24.33/32",
+                                                              "DestinationPrefix":  "10.127.130.36/32",
                                                               "NeedEncap":  true
                                                           }
                                             }

--- a/Kubernetes/flannel/l2bridge/manifests/kube-flannel-example.yml
+++ b/Kubernetes/flannel/l2bridge/manifests/kube-flannel-example.yml
@@ -1,0 +1,138 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flannel
+subjects:
+- kind: ServiceAccount
+  name: flannel
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flannel
+  namespace: kube-system
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kube-flannel-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    app: flannel
+data:
+  cni-conf.json: |
+    {
+      "name": "cbr0",
+      "type": "flannel",
+      "delegate": {
+        "isDefaultGateway": true
+      }
+    }
+  net-conf.json: |
+    {
+      "Network": "10.244.0.0/16",
+      "Backend": {
+        "Type": "host-gw"
+      }
+    }
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-flannel-ds
+  namespace: kube-system
+  labels:
+    tier: node
+    app: flannel
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: flannel
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+        beta.kubernetes.io/os: linux
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: flannel
+      initContainers:
+      - name: install-cni
+        image: quay.io/coreos/flannel:v0.9.1-amd64
+        command:
+        - cp
+        args:
+        - -f
+        - /etc/kube-flannel/cni-conf.json
+        - /etc/cni/net.d/10-flannel.conf
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      containers:
+      - name: kube-flannel
+        image: quay.io/coreos/flannel:v0.9.1-amd64
+        command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
+        securityContext:
+          privileged: true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: run
+          mountPath: /run
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      volumes:
+        - name: run
+          hostPath:
+            path: /run
+        - name: cni
+          hostPath:
+            path: /etc/cni/net.d
+        - name: flannel-cfg
+          configMap:
+            name: kube-flannel-cfg

--- a/Kubernetes/flannel/l2bridge/manifests/node-selector-patch.yml
+++ b/Kubernetes/flannel/l2bridge/manifests/node-selector-patch.yml
@@ -1,0 +1,5 @@
+spec:
+  template:
+    spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux

--- a/Kubernetes/flannel/l2bridge/manifests/simpleweb.yml
+++ b/Kubernetes/flannel/l2bridge/manifests/simpleweb.yml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: win-webserver
+  labels:
+    app: win-webserver
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 80
+    targetPort: 80
+  selector:
+    app: win-webserver
+  type: NodePort
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: win-webserver
+  name: win-webserver
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: win-webserver
+      name: win-webserver
+    spec:
+      containers:
+      - name: windowswebserver
+        image: microsoft/windowsservercore:1803
+        command:
+        - powershell.exe
+        - -command
+        - "<#code used from https://gist.github.com/wagnerandrade/5424431#> ; $$listener = New-Object System.Net.HttpListener ; $$listener.Prefixes.Add('http://*:80/') ; $$listener.Start() ; $$callerCounts = @{} ; Write-Host('Listening at http://*:80/') ; while ($$listener.IsListening) { ;$$context = $$listener.GetContext() ;$$requestUrl = $$context.Request.Url ;$$clientIP = $$context.Request.RemoteEndPoint.Address ;$$response = $$context.Response ;Write-Host '' ;Write-Host('> {0}' -f $$requestUrl) ;  ;$$count = 1 ;$$k=$$callerCounts.Get_Item($$clientIP) ;if ($$k -ne $$null) { $$count += $$k } ;$$callerCounts.Set_Item($$clientIP, $$count) ;$$ip=(Get-NetAdapter | Get-NetIpAddress); $$header='<html><body><H1>Windows Container Web Server</H1>' ;$$callerCountsString='' ;$$callerCounts.Keys | % { $$callerCountsString+='<p>IP {0} callerCount {1} ' -f $$ip[1].IPAddress,$$callerCounts.Item($$_) } ;$$footer='</body></html>' ;$$content='{0}{1}{2}' -f $$header,$$callerCountsString,$$footer ;Write-Output $$content ;$$buffer = [System.Text.Encoding]::UTF8.GetBytes($$content) ;$$response.ContentLength64 = $$buffer.Length ;$$response.OutputStream.Write($$buffer, 0, $$buffer.Length) ;$$response.Close() ;$$responseStatus = $$response.StatusCode ;Write-Host('< {0}' -f $$responseStatus)  } ; "
+      nodeSelector:
+        beta.kubernetes.io/os: windows

--- a/Kubernetes/flannel/l2bridge/net-conf.json
+++ b/Kubernetes/flannel/l2bridge/net-conf.json
@@ -1,5 +1,5 @@
 {
-  "Network": "192.168.0.0/16",
+  "Network": "10.244.0.0/16",
   "Backend": {
     "name": "cbr0",
     "type": "host-gw"

--- a/Kubernetes/flannel/l2bridge/start-kubelet.ps1
+++ b/Kubernetes/flannel/l2bridge/start-kubelet.ps1
@@ -1,14 +1,14 @@
 Param(
-    $clusterCIDR="192.168.0.0/16",
+    [parameter(Mandatory = $false)] $clusterCIDR="10.244.0.0/16",
+    [parameter(Mandatory = $false)] $KubeDnsServiceIP="10.96.0.10",
+    [parameter(Mandatory = $false)] $serviceCIDR="10.96.0.0/12",
+    [parameter(Mandatory = $false)] $KubeDnsSuffix="svc.cluster.local",
     $NetworkName = "cbr0",
     [switch] $RegisterOnly
 )
 
 $NetworkMode = "L2Bridge"
 # Todo : Get these values using kubectl
-$KubeDnsSuffix ="svc.cluster.local"
-$KubeDnsServiceIp="11.0.0.10"
-$serviceCIDR="11.0.0.0/8"
 
 $WorkingDir = "c:\k"
 $CNIPath = [Io.path]::Combine($WorkingDir , "cni")
@@ -16,7 +16,6 @@ $CNIConfig = [Io.path]::Combine($CNIPath, "config", "cni.conf")
 
 $endpointName = "cbr0"
 $vnicName = "vEthernet ($endpointName)"
-
 
 function
 IsNodeRegistered()
@@ -120,7 +119,7 @@ Update-CNIConfig($podCIDR)
   "delegate": {
      "type": "l2bridge",
       "dns" : {
-        "Nameservers" : [ "11.0.0.10" ],
+        "Nameservers" : [ "10.96.0.10" ],
         "Search": [ "svc.cluster.local" ]
       },
       "AdditionalArgs" : [
@@ -140,7 +139,7 @@ Update-CNIConfig($podCIDR)
 
     $configJson =  ConvertFrom-Json $jsonSampleConfig
     $configJson.name = "cbr0"
-    $configJson.delegate.dns.Nameservers[0] = $KubeDnsServiceIp
+    $configJson.delegate.dns.Nameservers[0] = $KubeDnsServiceIP
     $configJson.delegate.dns.Search[0] = $KubeDnsSuffix
 
     $configJson.delegate.AdditionalArgs[0].Value.ExceptionList[0] = $clusterCIDR
@@ -170,7 +169,7 @@ Update-CNIConfig $podCIDR
 c:\k\kubelet.exe --hostname-override=$(hostname) --v=6 `
     --pod-infra-container-image=kubeletwin/pause --resolv-conf="" `
     --allow-privileged=true --enable-debugging-handlers `
-    --cluster-dns=$KubeDnsServiceIp --cluster-domain=cluster.local `
+    --cluster-dns=$KubeDnsServiceIP --cluster-domain=cluster.local `
     --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge `
     --image-pull-progress-deadline=20m --cgroups-per-qos=false `
     --enforce-node-allocatable="" `

--- a/Kubernetes/flannel/l2bridge/start.ps1
+++ b/Kubernetes/flannel/l2bridge/start.ps1
@@ -1,6 +1,8 @@
 ﻿Param(
-    [parameter(Mandatory = $false)] $clusterCIDR="192.168.0.0/16",
-    [parameter(Mandatory = $true)] $ManagementIP
+    [parameter(Mandatory = $true)] $ClusterCIDR,
+    [parameter(Mandatory = $true)] $ManagementIP,
+    [parameter(Mandatory = $true)] $KubeDnsServiceIP,
+    [parameter(Mandatory = $true)] $ServiceCIDR
 )
 
 function DownloadFlannelBinaries()
@@ -16,11 +18,10 @@ function DownloadCniBinaries()
     md $BaseDir\cni\config -ErrorAction Ignore
     md C:\etc\kube-flannel -ErrorAction Ignore
 
-    Start-BitsTransfer  "https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/cni/config/cni.conf" -Destination $BaseDir\cni\config\cni.conf
     Start-BitsTransfer  "https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/cni/l2bridge.exe" -Destination $BaseDir\cni\l2bridge.exe
     Start-BitsTransfer  "https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/cni/flannel.exe" -Destination $BaseDir\cni\flannel.exe
     Start-BitsTransfer  "https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/cni/host-local.exe" -Destination $BaseDir\cni\host-local.exe
-    Start-BitsTransfer  "https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/net-conf.json" -Destination C:\etc\kube-flannel\net-conf.json
+    cp $BaseDir\net-conf.json C:\etc\kube-flannel\net-conf.json
 }
 
 function DownloadWindowsKubernetesScripts()
@@ -30,8 +31,6 @@ function DownloadWindowsKubernetesScripts()
     Start-BitsTransfer  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/InstallImages.ps1 -Destination $BaseDir\InstallImages.ps1
     Start-BitsTransfer  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/Dockerfile -Destination $BaseDir\Dockerfile
     Start-BitsTransfer  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/stop.ps1 -Destination $BaseDir\stop.ps1
-    Start-BitsTransfer  https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/start-kubelet.ps1 -Destination $BaseDir\start-Kubelet.ps1
-    Start-BitsTransfer  https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/start-kubeproxy.ps1 -Destination $BaseDir\start-Kubeproxy.ps1
 }
 
 function DownloadAllFiles()
@@ -92,6 +91,6 @@ powershell $BaseDir\start-kubelet.ps1 -RegisterOnly
 
 StartFlanneld $ManagementIP
 
-Start powershell -ArgumentList "-File $BaseDir\start-kubelet.ps1 -clusterCIDR $clusterCIDR -NetworkName $NetworkName"
+Start powershell -ArgumentList "-File $BaseDir\start-kubelet.ps1 -clusterCIDR $ClusterCIDR -KubeDnsServiceIP $KubeDnsServiceIP -serviceCIDR $ServiceCIDR -NetworkName $NetworkName"
 Start-Sleep 10
 start powershell -ArgumentList " -File $BaseDir\start-kubeproxy.ps1 -NetworkName $NetworkName"


### PR DESCRIPTION
1. Updated start.ps1 to require specifying cluster CIDR, service CIDR, etc. manually rather than defaulting to something that may not work. In a future PR we can determine this automatically in the script.

2. Added example manifest file for NodeSelectors to target Linux only (to stop interference with scripts from kube-proxy)

3. Removed downloading of some files (since this overwrites your changes each time you launch the script)

4. Updated readme.md with additional instructions