### PR TITLE
PS filtering fails with Get-HnsNetwork -Verbose argument

### DIFF
--- a/Kubernetes/windows/helper.psm1
+++ b/Kubernetes/windows/helper.psm1
@@ -51,7 +51,7 @@ function CleanupOldNetwork($NetworkMode)
 function WaitForNetwork($NetworkMode)
 {
     # Wait till the network is available
-    while( !(Get-HnsNetwork -Verbose | ? Type -EQ $NetworkMode.ToLower()) )
+    while( !(Get-HnsNetwork | ? Type -EQ $NetworkMode.ToLower()) )
     {
         Write-Host "Waiting for the Network to be created"
         Start-Sleep 10


### PR DESCRIPTION
With -Verbose the result is not empty:
![image](https://user-images.githubusercontent.com/3913941/43161232-5f35088a-8f3c-11e8-8f0f-8f47d4b7d9ce.png)

Without it it works:
![image](https://user-images.githubusercontent.com/3913941/43161267-78695aa4-8f3c-11e8-8a6b-26fae6651d11.png)
