### PR TITLE
Fix running in remote powershell sessions

### DIFF
--- a/Kubernetes/windows/debug/collectlogs.ps1
+++ b/Kubernetes/windows/debug/collectlogs.ps1
@@ -8,7 +8,7 @@ md $BaseDir -ErrorAction Ignore
 $helper = "$BaseDir\helper.psm1"
 if (!(Test-Path $helper))
 {
-    Start-BitsTransfer https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -Destination $BaseDir\helper.psm1
+    Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -OutFile $BaseDir\helper.psm1
 }
 ipmo $helper
 

--- a/Kubernetes/windows/helper.psm1
+++ b/Kubernetes/windows/helper.psm1
@@ -12,11 +12,11 @@ function DownloadFile()
     }
 
     try {
-        Start-BitsTransfer $Url -Destination $Destination
+        (New-Object System.Net.WebClient).DownloadFile($Url,$Destination)
         Write-Host "Downloaded $Url=>$Destination"
     } catch {
         Write-Error "Failed to download $Url"
-	throw
+	    throw
     }
 }
 


### PR DESCRIPTION
`Start-BitsTransfer` won't work through PowerShell remoting. `Invoke-WebRequest -UseBasicParsing` will. That's needed to get the first helper.psm1, then the DownloadFile calls will succeed