### PR TITLE
Minor fixes to SLB and Gateway failures when using SDNExpress

### DIFF
--- a/SDNExpress/scripts/SDNExpress.ps1
+++ b/SDNExpress/scripts/SDNExpress.ps1
@@ -211,6 +211,7 @@ write-SDNExpressLog "STAGE 1.3: Create Gateway VMs"
 
 foreach ($Gateway in $ConfigData.Gateways) {
     $params.ComputerName=$Gateway.HostName;
+    $params.InstallRasRoutingProtocols = $true;
     $params.VMName=$Gateway.ComputerName;
     $params.Nics=@(
         @{Name="Management"; MacAddress=$Gateway.MacAddress; IPAddress="$($Gateway.ManagementIP)/$ManagementSubnetBits"; Gateway=$ConfigData.ManagementGateway; DNS=$ConfigData.ManagementDNS; VLANID=$ConfigData.ManagementVLANID}
@@ -229,6 +230,7 @@ foreach ($NC in $ConfigData.NCs) {
 }
 
 WaitforComputertobeready $NCNodes $false
+
 
 New-SDNExpressNetworkController -ComputerNames $NCNodes -RESTName $ConfigData.RestName -Credential $Credential
 

--- a/SDNExpress/scripts/SDNExpressModule.psm1
+++ b/SDNExpress/scripts/SDNExpressModule.psm1
@@ -1027,6 +1027,7 @@ function WaitForComputerToBeReady
 
     foreach ($computer in $computername) {        
         write-sdnexpresslog "Waiting for $Computer to become active."
+        Start-Sleep -Seconds 120
         
         $continue = $true
         while ($continue) {
@@ -1622,6 +1623,7 @@ function New-SDNExpressVM
         [int] $VMProcessorCount = 8,
         [String] $Locale = [System.Globalization.CultureInfo]::CurrentCulture.Name,
         [String] $TimeZone = [TimeZoneInfo]::Local.Id
+        [Bool] $InstallRasRoutingProtocols
         )
 
     write-sdnexpresslog "New-SDNExpressVM"
@@ -1723,6 +1725,11 @@ function New-SDNExpressVM
     New-Item -ItemType Directory -Force -Path $MountPath | out-null
     
     Mount-WindowsImage -ImagePath $VHDVMPath -Index 1 -path $MountPath | out-null
+
+    If ($InstallRasRoutingProtocols) {
+        write-sdnexpresslog "Installing RasRoutingProtocols Offline"
+        Enable-WindowsOptionalFeature -Path $MountPath -FeatureName RasRoutingProtocols -All -LimitAccess | Out-Null
+        }
 
     write-sdnexpresslog "Generating unattend.xml"
 


### PR DESCRIPTION
 1. Added sleep command to function WaitForComputerToBeReady due to
failures in the deployment of SLBMuxes. VMs were still rebooting when
the script was trying to configure SLB.

2. When the GW VMs are created, added the installation of
Ras Routing protocols offline to get rid of the reboot required when
installing on core installations.