### PR TITLE
Get-NetView: Add per-file multithreading & correctly handle VM* objects with same name

### DIFF
--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -28,6 +28,8 @@
     Optional list of additional commands, given as ScriptBlocks. Their output is saved to the CustomModule directory,  
     which can be accessed by using "$CustomModule" as a placeholder. For example, {Copy-Item .\MyFile.txt $CustomModule}
     copies "MyFile.txt" to "CustomModule\MyFile.txt".
+.PARAMETER MaxThreads
+    Maximum number of simultaneous background tasks. TODO
 .PARAMETER SkipAdminCheck
     If this switch is present, then the check for administrator privileges will be skipped.
     Note that less data may be collected and the results may be of limited use.
@@ -52,13 +54,17 @@
 Param(
     [parameter(Mandatory=$false)]
     [ValidateScript({Test-Path $_ -PathType Container})]
-    [String] $OutputDirectory,
+    [String] $OutputDirectory = "",
 
     [parameter(Mandatory=$false)]
-    [ScriptBlock[]] $ExtraCommands,
+    [ScriptBlock[]] $ExtraCommands = @(),
 
     [parameter(Mandatory=$false)]
-    [Switch] $SkipAdminCheck
+    [ValidateRange(0, [Int]::MaxValue)]
+    [Int] $MaxThreads = 0,
+
+    [parameter(Mandatory=$false)]
+    [Switch] $SkipAdminCheck = $false
 )
 
 #
@@ -66,8 +72,8 @@ Param(
 #
 
 $ExecFunctions = {
-    # Global vars
     $columns   = 4096
+    $Global:ThreadPool = $null
 
     function ExecCommandText {
         [CmdletBinding()]
@@ -207,6 +213,36 @@ $ExecFunctions = {
 
 . $ExecFunctions # import into script context
 
+function Initialize-GlobalThreadPool {
+    [CmdletBinding()]
+    Param(
+        [Int] $MaxThreads = 0
+    )
+
+    if ($MaxThreads -eq 0)
+    {
+        $MaxThreads = 4 # TODO base on hardware
+    }
+
+    if ($Global:ThreadPool -eq $null)
+    {
+        $Global:ThreadPool = [RunspaceFactory]::CreateRunspacePool(1, $MaxThreads)
+        $Global:ThreadPool.Open()
+    }
+}
+
+function Close-GlobalThreadPool {
+    [CmdletBinding()]
+    Param()
+
+    if ($Global:ThreadPool -ne $null)
+    {
+        $Global:ThreadPool.Close()
+        $Global:ThreadPool.Dispose()
+        $Global:ThreadPool = $null
+    }
+}
+
 function Start-Thread {
     [CmdletBinding()]
     Param(
@@ -217,8 +253,7 @@ function Start-Thread {
 
     $ps = [PowerShell]::Create()
 
-    $ps.Runspace = [RunspaceFactory]::CreateRunspace()
-    $ps.Runspace.Open()
+    $ps.RunspacePool = $Global:ThreadPool
     $null = $ps.AddScript("Set-Location ""$(Resolve-Path $StartPath)""")
     $null = $ps.AddScript($ExecFunctions) # import into thread context
     $null = $ps.AddScript($ScriptBlock).AddParameters($Params)
@@ -236,7 +271,6 @@ function Remove-Thread {
     Write-Host "Stopping thread $($Thread.Name)..."
     $Thread.PowerShell.Stop()
     $Thread.PowerShell.Dispose()
-    $Thread.PowerShell.Runspace.Close()
 } # Remove-Thread
 
 function StreamThread {
@@ -1652,9 +1686,9 @@ function VMSwitchDetail {
     ##See this command to get VFs on vSwitch
     #Get-NetAdapterSriovVf -SwitchId 2
 
-    foreach ($switch in TryCmd {Get-VMSwitch}) {
-        $name = $switch.Name
-        $type = $switch.SwitchType
+    foreach ($vSwitch in TryCmd {Get-VMSwitch}) {
+        $name = $vSwitch.Name
+        $type = $vSwitch.SwitchType
 
         $dir  = (Join-Path -Path $OutDir -ChildPath ("VMSwitch.$type.$name"))
         New-Item -ItemType directory -Path $dir | Out-Null
@@ -2084,6 +2118,7 @@ function NetshTrace {
         ExecCommand -Trusted -Command $cmd -Output $out
     }
 } # NetshTrace()
+
 function OneX {
     [CmdletBinding()]
     Param(
@@ -2315,7 +2350,7 @@ function NormalizeWorkDir {
     )
 
     # Output dir priority - $OutputDirectory, Desktop, Temp
-    $baseDir = if ($OutputDirectory) {
+    $baseDir = if (-not [String]::IsNullOrWhiteSpace($OutputDirectory)) {
                    if (Test-Path $OutputDirectory) {
                        (Resolve-Path $OutputDirectory).Path # full path
                    } else {
@@ -2447,17 +2482,20 @@ function Get-NetView {
     Param(
         [parameter(Mandatory=$false)]
         [ValidateScript({Test-Path $_ -PathType Container})]
-        [String] $OutputDirectory,
+        [String] $OutputDirectory = "",
+    
+        [parameter(Mandatory=$false)]
+        [ScriptBlock[]] $ExtraCommands = @(),
+
+        [ValidateRange(0, [Int]::MaxValue)]
+        [Int] $MaxThreads = 0,
 
         [parameter(Mandatory=$false)]
-        [ScriptBlock[]] $ExtraCommands,
-
-        [parameter(Mandatory=$false)]
-        [Switch] $SkipAdminCheck
+        [Switch] $SkipAdminCheck = $false
     )
 
     $start = Get-Date
-    $version = "2018.07.13.0" # Version within date context
+    $version = "2018.09.05.0" # Version within date context
 
     # Input Validation
     CheckAdminPrivileges $SkipAdminCheck
@@ -2469,6 +2507,8 @@ function Get-NetView {
     # Start Run
     try {
         CustomModule      -OutDir $workDir -Commands $ExtraCommands
+
+        Initialize-GlobalThreadPool -MaxThreads $MaxThreads
 
         # concurrent execution of slow commands
         $threads = if ($true) {
@@ -2506,6 +2546,8 @@ function Get-NetView {
     } finally {
         Write-Host "Removing background threads..."
         $threads | foreach {Remove-Thread $_}
+
+        Close-GlobalThreadPool
     }
 
     Completion -Src $workDir

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -936,7 +936,7 @@ function NativeNicDetail {
         $native = $true
 
         # Skip vSwitch Host vNICs by checking the driver
-        if ($nic.DriverFileName -like "vmswitch.sys") {
+        if (@("vmswitch.sys", "VmsProxyHNic.sys") -contains $nic.DriverFileName) {
             continue
         }
 

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -1079,7 +1079,7 @@ function VMNetworkAdapterDetail {
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterAcl.txt"
-    [String []] $cmds = "Get-VMNetworkAdapterAcl -VMNetworkAdpater $vmNicObject | Out-String -Width $columns",
+    [String []] $cmds = "Get-VMNetworkAdapterAcl -VMNetworkAdapter $vmNicObject | Out-String -Width $columns",
                         "Get-VMNetworkAdapterAcl -VMNetworkAdapter $vmNicObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -29,7 +29,7 @@
     which can be accessed by using "$CustomModule" as a placeholder. For example, {Copy-Item .\MyFile.txt $CustomModule}
     copies "MyFile.txt" to "CustomModule\MyFile.txt".
 .PARAMETER MaxThreads
-    Maximum number of simultaneous background tasks, from 1 to 10. Defaults to 4.
+    Maximum number of simultaneous background tasks, from 1 to 10. Defaults to 5.
 .PARAMETER SkipAdminCheck
     If this switch is present, then the check for administrator privileges will be skipped.
     Note that less data may be collected and the results may be of limited use.
@@ -61,7 +61,7 @@ Param(
 
     [parameter(Mandatory=$false)]
     [ValidateRange(1, 16)]
-    [Int] $MaxThreads = 4,
+    [Int] $MaxThreads = 5,
 
     [parameter(Mandatory=$false)]
     [Switch] $SkipAdminCheck = $false
@@ -1970,7 +1970,7 @@ function Get-NetView {
         [ScriptBlock[]] $ExtraCommands = @(),
 
         [ValidateRange(1, 16)]
-        [Int] $MaxThreads = 4,
+        [Int] $MaxThreads = 5,
 
         [parameter(Mandatory=$false)]
         [Switch] $SkipAdminCheck = $false

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -25,7 +25,7 @@
     Optional path to the directory where the output should be saved. Can be either a relative or an absolute path.
     If unspecified, the current user's Desktop will be used by default.
 .PARAMETER ExtraCommands
-    Optional list of additional commands, given as ScriptBlocks. Their output is saved to the CustomModule directory,  
+    Optional list of additional commands, given as ScriptBlocks. Their output is saved to the CustomModule directory,
     which can be accessed by using "$CustomModule" as a placeholder. For example, {Copy-Item .\MyFile.txt $CustomModule}
     copies "MyFile.txt" to "CustomModule\MyFile.txt".
 .PARAMETER MaxThreads
@@ -84,11 +84,11 @@ $ExecFunctions = {
 
         # Mirror command execution context
         $context = "$env:USERNAME @ ${env:COMPUTERNAME}:"
-        Write-Output $context | Out-File -Encoding ascii -Append $Output
+        Write-Output $context | Out-File -Encoding Ascii -Append $Output
 
         # Mirror command to execute
         $cmdMirror = "$(prompt)$Command"
-        Write-Output $cmdMirror | Out-File -Encoding ascii -Append $Output
+        Write-Output $cmdMirror | Out-File -Encoding Ascii -Append $Output
     } # ExecCommandText()
 
     function ExecCommandPrivate {
@@ -101,7 +101,7 @@ $ExecFunctions = {
         ExecCommandText -Command ($Command) -Output $Output
 
         # Execute Command and redirect to file.  Useful so users know what to run!!!
-        Invoke-Expression $Command | Out-File -Encoding ascii -Append $Output
+        Invoke-Expression $Command | Out-File -Encoding Ascii -Append $Output
     } #ExecCommandPrivate()
 
     enum CommandStatus {
@@ -197,7 +197,7 @@ $ExecFunctions = {
             [parameter(Mandatory=$true)] [String] $OutDir,
             [parameter(Mandatory=$true)] [String[]] $Commands
         )
-    
+
         $out = (Join-Path -Path $OutDir -ChildPath $File)
         foreach ($cmd in $Commands) {
             ExecCommand -Trusted:$Trusted -Command ($cmd) -Output $out
@@ -222,7 +222,7 @@ function TryCmd {
     # Returning $null will cause foreach to iterate once
     # unless TryCmd call is in parentheses.
     if ($out -eq $null) {
-        $out = @() 
+        $out = @()
     }
 
     return $out
@@ -274,29 +274,37 @@ function Start-Thread {
     return @{Name=$ScriptBlock.Ast.Name; AsyncResult=$async; PowerShell=$ps}
 } # Start-Thread()
 
-function Show-Thread {
+function Show-Threads {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [Hashtable] $Thread
+        [parameter(Mandatory=$true)] [Hashtable[]] $Threads
     )
 
-    while ($true) {
-        $Thread.Powershell.Streams.Error | Out-Host
-        $Thread.PowerShell.Streams.Warning | Out-Host
-        $Thread.PowerShell.Streams.Information | Out-Host
+    $mThreads = [Collections.ArrayList]$Threads
 
-        $Thread.PowerShell.Streams.ClearStreams()
+    while ($mThreads.Count -gt 0) {
+        for ($i = 0; $i -lt $mThreads.Count; $i++) {
+            $thread = $mThreads[$i]
 
-        if ($Thread.AsyncResult.IsCompleted)
-        {
-            break
+            $thread.Powershell.Streams.Warning | Out-Host
+            $thread.Powershell.Streams.Warning.Clear()
+            $thread.Powershell.Streams.Information | Out-Host
+            $thread.Powershell.Streams.Information.Clear()
+
+            if ($thread.AsyncResult.IsCompleted)
+            {
+                # Accessing Streams.Error blocks until thread is completed
+                $thread.Powershell.Streams.Error | Out-Host
+                $thread.Powershell.Streams.Error.Clear()
+
+                $thread.PowerShell.EndInvoke($thread.AsyncResult)
+                $mThreads.RemoveAt($i)
+                $i--
+            }
         }
-
-        Start-Sleep -Milliseconds 16.667
+        Start-Sleep -Milliseconds 15
     }
-
-    $Thread.PowerShell.EndInvoke($Thread.AsyncResult)
-} # Show-Thread()
+} # Show-Threads()
 
 function ExecCommandsAsync {
     [CmdletBinding()]
@@ -307,6 +315,8 @@ function ExecCommandsAsync {
         [parameter(Mandatory=$true)] [String[]] $Commands
     )
 
+    # uncomment to make script run linearly
+    #return ExecCommands @PSBoundParameters
     return Start-Thread -ScriptBlock ${function:ExecCommands} -Params $PSBoundParameters
 } # ExecCommandsAsync()
 
@@ -665,11 +675,12 @@ function LbfoWorker {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $name = $LbfoName
-    $dir  = (Join-Path -Path $OutDir -ChildPath "LBFO.$name")
+    $name  = $LbfoName
+    $title = "LBFO.$name"
+    $dir   = (Join-Path -Path $OutDir -ChildPath "$title")
     New-Item -ItemType directory -Path $dir | Out-Null
 
-    Write-Host "Processing: $name"
+    Write-Host "Processing: $title"
     $file = "Get-NetLbfoTeam.txt"
     [String []] $cmds = "Get-NetLbfoTeam -Name ""$name""",
                         "Get-NetLbfoTeam -Name ""$name"" | Format-List  -Property *",
@@ -733,14 +744,15 @@ function LbfoDetail {
 function ProtocolNicDetail {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $VMSwitchName,
+        [parameter(Mandatory=$true)] [String] $VMSwitchId,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
+    $id  = $VMSwitchId
     $dir = $OutDir
 
     # Distinguish between LBFO from standard PTNICs and create the hierarchies accordingly
-    foreach ($desc in TryCmd {(Get-VMSwitch -Name "$VMSwitchName").NetAdapterInterfaceDescriptions}) {
+    foreach ($desc in TryCmd {(Get-VMSwitch -Id $id).NetAdapterInterfaceDescriptions}) {
         $nic = Get-NetAdapter -InterfaceDescription $desc
         if ($nic.DriverFileName -like "NdisImPlatform.sys") {
             LbfoWorker -LbfoName $nic.Name -OutDir $dir
@@ -1043,14 +1055,14 @@ function HostVNicWorker {
 function HostVNicDetail {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $VMSwitchName,
+        [parameter(Mandatory=$true)] [String] $VMSwitchId,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
     # Cache output
     $allNetAdapters = Get-NetAdapter -IncludeHidden
 
-    foreach ($nic in TryCmd {Get-VMNetworkAdapter -ManagementOS -SwitchName $VMSwitchName}) {
+    foreach ($nic in TryCmd {Get-VMNetworkAdapter -ManagementOS} | where {$_.SwitchId -eq $VMSwitchId}) {
         <#
             Correlate to VMNic instance to NetAdapter instance view
             Physical to Virtual Mapping.
@@ -1078,7 +1090,7 @@ function HostVNicDetail {
         New-Item -ItemType directory -Path $dir | Out-Null
 
         Write-Host "Processing: $title"
-        $threads = NetIpNic         -NicName      $pnicname -OutDir $dir
+        NetIpNic         -NicName      $pnicname -OutDir $dir
         HostVNicWorker   -HostVNicName $name     -OutDir $dir
         NetAdapterWorker -NicName      $pnicname -OutDir $dir
     }
@@ -1089,222 +1101,223 @@ function VMNetworkAdapterDetail {
     Param(
         [parameter(Mandatory=$true)] [String] $VMName,
         [parameter(Mandatory=$true)] [String] $VMNicName,
-        [parameter(Mandatory=$true)] [String] $VMNicMac,
+        [parameter(Mandatory=$true)] [String] $VMNicId,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $name = $VMNicName
-    $title = "VMNic.$VMNicName.$VMNicMac"
-    $dir  = (Join-Path -Path $OutDir -ChildPath $title)
+    $name  = $VMNicName
+    $id    = $VMNicId
+    $title = "VMNic.$name.$id"
+    $dir   = (Join-Path -Path $OutDir -ChildPath "$title")
     New-Item -ItemType directory -Path $dir | Out-Null
+
+    # We must use Id to identity VMNics, because different VMNics
+    # can have the same MAC (if VM is off), Name, VMName, and SwitchName.
+    [String] $vmNicObject = "`$(Get-VMNetworkAdapter -VMName ""$VMName"" | where {(`$_.Id -split ""\\"")[1] -eq ""$id""})"
 
     Write-Host "Processing: $title"
     $file = "Get-VMNetworkAdapter.txt"
-    [String []] $cmds = "Get-VMNetworkAdapter -Name ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapter -Name ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
-                        "Get-VMNetworkAdapter * | Get-Member"
+    [String []] $cmds = "$vmNicObject | Out-String -Width $columns",
+                        "$vmNicObject | Format-List -Property *",
+                        "$vmNicObject | Get-Member"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterAcl.txt"
-    [String []] $cmds = "Get-VMNetworkAdapterAcl -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterAcl -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
+    [String []] $cmds = "Get-VMNetworkAdapterAcl -VMNetworkAdpater $vmNicObject | Out-String -Width $columns",
+                        "Get-VMNetworkAdapterAcl -VMNetworkAdapter $vmNicObject | Format-List -Property *",
                         "Get-VMNetworkAdapterAcl | Get-Member"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterExtendedAcl.txt"
-    [String []] $cmds = "Get-VMNetworkAdapterExtendedAcl -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterExtendedAcl -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
+    [String []] $cmds = "Get-VMNetworkAdapterExtendedAcl -VMNetworkAdapter $vmNicObject | Out-String -Width $columns",
+                        "Get-VMNetworkAdapterExtendedAcl -VMNetworkAdapter $vmNicObject | Format-List -Property *",
                         "Get-VMNetworkAdapterExtendedAcl | Get-Member"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterFailoverConfiguration.txt"
-    [String []] $cmds = "Get-VMNetworkAdapterFailoverConfiguration -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterFailoverConfiguration -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
-                        "Get-VMNetworkAdapterFailoverConfiguration -VMName * | Get-Member"
+    [String []] $cmds = "Get-VMNetworkAdapterFailoverConfiguration -VMNetworkAdapter $vmNicObject | Out-String -Width $columns",
+                        "Get-VMNetworkAdapterFailoverConfiguration -VMNetworkAdapter $vmNicObject | Format-List -Property *",
+                        "Get-VMNetworkAdapterFailoverConfiguration | Get-Member"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterIsolation.txt"
-    [String []] $cmds = "Get-VMNetworkAdapterIsolation -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterIsolation -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
+    [String []] $cmds = "Get-VMNetworkAdapterIsolation -VMNetworkAdapter $vmNicObject | Out-String -Width $columns",
+                        "Get-VMNetworkAdapterIsolation -VMNetworkAdapter $vmNicObject | Format-List -Property *",
                         "Get-VMNetworkAdapterIsolation | Get-Member"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterRoutingDomainMapping.txt"
-    [String []] $cmds = "Get-VMNetworkAdapterRoutingDomainMapping -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterRoutingDomainMapping -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
+    [String []] $cmds = "Get-VMNetworkAdapterRoutingDomainMapping -VMNetworkAdapter $vmNicObject | Out-String -Width $columns",
+                        "Get-VMNetworkAdapterRoutingDomainMapping -VMNetworkAdapter $vmNicObject | Format-List -Property *",
                         "Get-VMNetworkAdapterRoutingDomainMapping | Get-Member"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterTeamMapping.txt"
-    [String []] $cmds = "Get-VMNetworkAdapterTeamMapping -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterTeamMapping -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
-                        "Get-VMNetworkAdapterTeamMapping -VMName * | Get-Member"
+    [String []] $cmds = "Get-VMNetworkAdapterTeamMapping -VMNetworkAdapter $vmNicObject | Out-String -Width $columns",
+                        "Get-VMNetworkAdapterTeamMapping -VMNetworkAdapter $vmNicObject | Format-List -Property *",
+                        "Get-VMNetworkAdapterTeamMapping | Get-Member"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterVlan.txt"
-    [String []] $cmds = "Get-VMNetworkAdapterVlan -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterVlan -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
+    [String []] $cmds = "Get-VMNetworkAdapterVlan -VMNetworkAdapter $vmNicObject | Out-String -Width $columns",
+                        "Get-VMNetworkAdapterVlan -VMNetworkAdapter $vmNicObject | Format-List -Property *",
                         "Get-VMNetworkAdapterVlan | Get-Member"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
+
+    $file = "Get-VMSwitchExtensionPortFeature.txt"
+    [String []] $cmds = "Get-VMSwitchExtensionPortFeature -VMNetworkAdapter $vmNicObject | Format-List -Property *",
+                        "Get-VMSwitchExtensionPortFeature | Get-Member"
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
+
+    $file = "Get-VMSwitchExtensionPortData.txt"
+    [String []] $cmds = "Get-VMSwitchExtensionPortData -VMNetworkAdapter $vmNicObject | Format-List -Property *",
+                        "Get-VMSwitchExtensionPortData | Get-Member"
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
+    #>
 } # VMNetworkAdapterDetail()
 
 function VMWorker {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $VMName,
+        [parameter(Mandatory=$true)] [String] $VMId,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $dir  = $OutDir
+    $id  = $VMId
+    $dir = $OutDir
+
+    # Different VMs can have the same name
+    [String] $vmObject = "`$(Get-VM -Id $id)"
 
     $file = "Get-VM.txt"
-    [String []] $cmds = "Get-VM -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VM -VMName ""$VMName"" | Format-List  -Property *",
-                        "Get-VM | Get-Member"
+    [String []] $cmds = "$vmObject | Out-String -Width $columns",
+                        "$vmObject | Format-List -Property *",
+                        "$vmObject | Get-Member"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMBios.txt"
-    [String []] $cmds = "Get-VMBios -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMBios -VMName ""$VMName"" | Format-List  -Property *"
+    [String []] $cmds = "Get-VMBios -VM $vmObject | Out-String -Width $columns",
+                        "Get-VMBios -VM $vmObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMFirmware.txt"
-    [String []] $cmds = "Get-VMFirmware -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMFirmware -VMName ""$VMName"" | Format-List  -Property *"
+    [String []] $cmds = "Get-VMFirmware -VM $vmObject | Out-String -Width $columns",
+                        "Get-VMFirmware -VM $vmObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMProcessor.txt"
-    [String []] $cmds = "Get-VMProcessor -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMProcessor -VMName ""$VMName"" | Format-List  -Property *"
+    [String []] $cmds = "Get-VMProcessor -VM $vmObject | Out-String -Width $columns",
+                        "Get-VMProcessor -VM $vmObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMMemory.txt"
-    [String []] $cmds = "Get-VMMemory -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMMemory -VMName ""$VMName"" | Format-List  -Property *"
+    [String []] $cmds = "Get-VMMemory -VM $vmObject | Out-String -Width $columns",
+                        "Get-VMMemory -VM $vmObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMVideo.txt"
-    [String []] $cmds = "Get-VMVideo -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMVideo -VMName ""$VMName"" | Format-List  -Property *"
+    [String []] $cmds = "Get-VMVideo -VM $vmObject | Out-String -Width $columns",
+                        "Get-VMVideo -VM $vmObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMHardDiskDrive.txt"
-    [String []] $cmds = "Get-VMHardDiskDrive -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMHardDiskDrive -VMName ""$VMName"" | Format-List  -Property *"
+    [String []] $cmds = "Get-VMHardDiskDrive -VM $vmObject | Out-String -Width $columns",
+                        "Get-VMHardDiskDrive -VM $vmObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMComPort.txt"
-    [String []] $cmds = "Get-VMComPort -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMComPort -VMName ""$VMName"" | Format-List  -Property *"
+    [String []] $cmds = "Get-VMComPort -VM $vmObject | Out-String -Width $columns",
+                        "Get-VMComPort -VM $vmObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSecurity.txt"
-    [String []] $cmds = "Get-VMSecurity -VMName ""$VMName"" | Out-String -Width $columns",
-                        "Get-VMSecurity -VMName ""$VMName"" | Format-List  -Property *"
+    [String []] $cmds = "Get-VMSecurity -VM $vmObject | Out-String -Width $columns",
+                        "Get-VMSecurity -VM $vmObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # VMWorker()
 
 function VMNetworkAdapterPerVM {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $VMSwitchName,
+        [parameter(Mandatory=$true)] [String] $VMSwitchId,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
+    [Int] $index = 0
     foreach ($vm in TryCmd {Get-VM}) {
-        $vmname = $vm.Name
-        $vmid   = $vm.VMId
+        $vmName = $vm.Name
+        $vmId   = $vm.VMId
+        $title  = "VM.$index.$vmName"
 
-        Write-Host "Processing: VM.$vmname.$vmid"
-        foreach ($nic in TryCmd {Get-VMNetworkAdapter -VMName $vmname}) {
-            if ($nic.SwitchName -eq $VMSwitchName) {
-                $vmquery = 0
-                $dir     = (Join-Path -Path $OutDir -ChildPath ("VM.$vmname"))
-                if (-not (Test-Path $dir)) {
-                    New-Item -ItemType directory -Path $dir | Out-Null
-                    $vmquery = 1
-                }
+        $dir    = (Join-Path -Path $OutDir -ChildPath "$title")
 
-                if ($vmquery) {
-                    VMWorker -VMName $vmname -OutDir $dir
-                }
-                VmNetworkAdapterDetail -VMName $vmname -VMNicName $nic.Name -VMNicMac $nic.MacAddress -OutDir $dir
+        $vmQuery = $false
+        foreach ($vmNic in TryCmd {Get-VMNetworkAdapter -VM $vm} | where {$_.SwitchId -eq $VMSwitchId}) {
+            $vmNicId = ($vmNic.Id -split "\\")[1] # Same as AdapterId, but works if VM is off
+
+            if (-not $vmQuery)
+            {
+                Write-Host "Processing: $title"
+                New-Item -ItemType "Directory" -Path $dir | Out-Null
+                VMWorker -VMId $vmId -OutDir $dir
+                $vmQuery = $true
             }
+
+            VMNetworkAdapterDetail -VMName $vmName -VMNicName $vmNic.Name -VMNicId $vmNicId -OutDir $dir
         }
+
+        $index++
     }
 } # VMNetworkAdapterPerVM()
 
 function VMSwitchWorker {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $VMSwitchName,
+        [parameter(Mandatory=$true)] [String] $VMSwitchId,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $name = $VMSwitchName
-    $dir  = $OutDir
+    $id  = $VMSwitchId
+    $dir = $OutDir
+
+    $vmSwitchObject = "`$(Get-VMSwitch -Id $id)"
 
     $file = "Get-VMSwitch.txt"
-    [String []] $cmds = "Get-VMSwitch -Name ""$name""",
-                        "Get-VMSwitch -Name ""$name"" | Format-List  -Property *",
-                        "Get-VMSwitch -Name ""$name"" | Get-Member"
+    [String []] $cmds = "$vmSwitchObject",
+                        "$vmSwitchObject | Format-List -Property *",
+                        "$vmSwitchObject | Get-Member"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchExtension.txt"
-    [String []] $cmds = "Get-VMSwitch -Name ""$name"" | Get-VMSwitchExtension | Format-List  -Property *",
-                        "Get-VMSwitch -Name ""$name"" | Get-VMSwitchExtension | Get-Member"
+    [String []] $cmds = "Get-VMSwitchExtension -VMSwitch $vmSwitchObject | Format-List -Property *",
+                        "Get-VMSwitchExtension -VMSwitch $vmSwitchObject | Get-Member"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchExtensionSwitchData.txt"
-    [String []] $cmds = "Get-VMSwitchExtensionSwitchData -SwitchName ""$name"" | Format-List  -Property *",
-                        "Get-VMSwitchExtensionSwitchData -SwitchName ""$name"" | Get-Member"
+    [String []] $cmds = "Get-VMSwitchExtensionSwitchData -VMSwitch $vmSwitchObject | Format-List -Property *",
+                        "Get-VMSwitchExtensionSwitchData -VMSwitch $vmSwitchObject | Get-Member"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchExtensionSwitchFeature.txt"
-    [String []] $cmds = "Get-VMSwitchExtensionSwitchFeature -SwitchName ""$name"" | Format-List -Property *"
-                        #"Get-VMSwitchExtensionSwitchFeature -SwitchName ""$name"" | Get-Member"
+    [String []] $cmds = "Get-VMSwitchExtensionSwitchFeature -VMSwitch $vmSwitchObject | Format-List -Property *",
+                        "Get-VMSwitchExtensionSwitchFeature -VMSwitch $vmSwitchObject | Get-Member"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchTeam.txt"
-    [String []] $cmds = "Get-VMSwitchTeam -SwitchName ""$name"" | Format-List -Property *",
-                        "Get-VMSwitchTeam -SwitchName ""$name"" | Get-Member"
+    [String []] $cmds = "Get-VMSwitchTeam -VMSwitch $vmSwitchObject | Format-List -Property *",
+                        "Get-VMSwitchTeam | Get-Member"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
-
-    $file = "Get-VMSystemSwitchExtension.txt"
-    [String []] $cmds = "Get-VMSystemSwitchExtension | Format-List -Property *",
-                        "Get-VMSystemSwitchExtension | Get-Member"
-    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
-
-    $file = "Get-VMSwitchExtensionPortFeature.txt"
-    [String []] $cmds = "Get-VMSwitchExtensionPortFeature * | Format-List -Property *",
-                        "Get-VMSwitchExtensionPortFeature * | Get-Member"
-    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
-
-    $file = "Get-VMSystemSwitchExtensionSwitchFeature.txt"
-    [String []] $cmds = "Get-VMSystemSwitchExtensionSwitchFeature",
-                        "Get-VMSystemSwitchExtensionSwitchFeature | Format-List  -Property *",
-                        "Get-VMSystemSwitchExtensionSwitchFeature | Get-Member"
-    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
-
-    <#
-    #Get-VMSwitchExtensionPortData -ComputerName $env:computername *
-    # Execute command list
-    $file = "Get-VMSwitchExtensionPortData.txt"
-    [String []] $cmds = "Get-VMSwitchExtensionPortData -SwitchName ""$name"" | Format-List  -Property *",
-                        "Get-VMSwitchExtensionPortData -SwitchName ""$name"" | Get-Member"
-    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
-    #>
 } # VMSwitchWorker()
 
 function VfpExtensionDetail {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $VMSwitchName,
+        [parameter(Mandatory=$true)] [String] $VMSwitchId,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $name = $VMSwitchName
-    $vfpExtension = TryCmd {Get-VMSwitch -Name $name | Get-VMSwitchExtension} | where {$_.Name -like "Microsoft Azure VFP Switch Extension"}
+    $id = $VMSwitchId
+    $vfpExtension = TryCmd {Get-VMSwitch -Id $id | Get-VMSwitchExtension} | where {$_.Name -like "Microsoft Azure VFP Switch Extension"}
 
     if ($vfpExtension.Enabled -ne "True") {
         return
@@ -1319,7 +1332,7 @@ function VfpExtensionDetail {
 
     $switches = Get-WmiObject -Namespace "root\virtualization\v2" -Class "Msvm_VirtualEthernetSwitch"
     foreach ($vmSwitch in $switches) {
-        if ($vmSwitch.ElementName -eq $name) {
+        if ($vmSwitch.Name -eq $id) {
             $currswitch = $vmSwitch
             break
         }
@@ -1347,19 +1360,24 @@ function VMSwitchDetail {
     # See this command to get VFs on vSwitch
     # Get-NetAdapterSriovVf -SwitchId 2
 
+    [Int] $index = 0
     foreach ($vmSwitch in TryCmd {Get-VMSwitch}) {
-        $name = $vmSwitch.Name
-        $type = $vmSwitch.SwitchType
+        $name  = $vmSwitch.Name
+        $type  = $vmSwitch.SwitchType
+        $id    = $vmSwitch.Id
+        $title = "VMSwitch.$index.$type.$name"
 
-        $dir  = (Join-Path -Path $OutDir -ChildPath "VMSwitch.$type.$name")
+        $dir  = (Join-Path -Path $OutDir -ChildPath "$title")
         New-Item -ItemType directory -Path $dir | Out-Null
 
-        Write-Host "Processing: $name"
-        VfpExtensionDetail    -VMSwitchName $name -OutDir $dir
-        VMSwitchWorker        -VMSwitchName $name -OutDir $dir
-        ProtocolNicDetail     -VMSwitchName $name -OutDir $dir
-        HostVNicDetail        -VMSwitchName $name -OutDir $dir
-        VMNetworkAdapterPerVM -VMSwitchName $name -OutDir $dir
+        Write-Host "Processing: $title"
+        VfpExtensionDetail    -VMSwitchId $id -OutDir $dir
+        VMSwitchWorker        -VMSwitchId $id -OutDir $dir
+        ProtocolNicDetail     -VMSwitchId $id -OutDir $dir
+        HostVNicDetail        -VMSwitchId $id -OutDir $dir
+        VMNetworkAdapterPerVM -VMSwitchId $id -OutDir $dir
+
+        $index++
     }
 } # VMSwitchDetail()
 
@@ -1381,6 +1399,17 @@ function NetworkSummary {
                         "Get-VMNetworkAdapter -All | Sort-Object Name | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
+    $file = "Get-VMSystemSwitchExtension.txt"
+    [String []] $cmds = "Get-VMSystemSwitchExtension | Format-List -Property *",
+                        "Get-VMSystemSwitchExtension | Get-Member"
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
+
+    $file = "Get-VMSystemSwitchExtensionSwitchFeature.txt"
+    [String []] $cmds = "Get-VMSystemSwitchExtensionSwitchFeature",
+                        "Get-VMSystemSwitchExtensionSwitchFeature | Format-List -Property *",
+                        "Get-VMSystemSwitchExtensionSwitchFeature | Get-Member"
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
+
     $file = "Get-NetAdapter.txt"
     [String []] $cmds = "Get-NetAdapter -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -AutoSize",
                         "Get-NetAdapter -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -Property * -AutoSize | Out-String -Width $columns"
@@ -1388,7 +1417,7 @@ function NetworkSummary {
 
     $file = "Get-NetAdapterStatistics.txt"
     [String []] $cmds = "Get-NetAdapterStatistics -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -Autosize  | Out-String -Width $columns",
-                        "Get-NetAdapterStatistics -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -Property * -Autosize  | Out-String -Width $columns"
+                        "Get-NetAdapterStatistics -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -Property * -Autosize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetLbfoTeam.txt"
@@ -1458,7 +1487,7 @@ function NetSetupDetail {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $dir = (Join-Path -Path $OutDir -ChildPath ("NetSetup"))
+    $dir = (Join-Path -Path $OutDir -ChildPath "NetSetup")
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "NetSetup.txt"
@@ -1702,7 +1731,7 @@ function Counters {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $dir    = (Join-Path -Path $OutDir -ChildPath ("Counters"))
+    $dir = (Join-Path -Path $OutDir -ChildPath "Counters")
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "CounterSetName.txt"
@@ -1728,9 +1757,9 @@ function Counters {
     $cntrList = @("*Hyper*", "*vfp*", "*ip*", "*udp*", "*tcp*", "*icmp*", "*nat*", "*network*", "*rdma*", "*smb*", "*wfp*", "*Mellanox*", "*intel*")
     $cntrPaths = Get-Counter -ListSet $cntrList -ErrorAction SilentlyContinue | Sort-Object CounterSetName | ForEach-Object { $_.Paths }
 
-    Write-Host "Querying Perf Counters..."
+    Write-Host "Querying perf counters..."
     $cntrReadings = Get-Counter -Counter $cntrPaths -MaxSamples 5 -SampleInterval 8 -ErrorAction SilentlyContinue
-    Write-Host "Exporting Results..."
+    Write-Host "Exporting perf counters..."
     $cntrReadings | Export-Counter -Path "$out.blg" -FileFormat BLG
     $cntrReadings | Export-Counter -Path "$out.csv" -FileFormat CSV
 } # Counters()
@@ -2003,7 +2032,7 @@ function Get-NetView {
         [parameter(Mandatory=$false)]
         [ValidateScript({Test-Path $_ -PathType Container})]
         [String] $OutputDirectory = "",
-    
+
         [parameter(Mandatory=$false)]
         [ScriptBlock[]] $ExtraCommands = @(),
 
@@ -2053,10 +2082,11 @@ function Get-NetView {
             NetIp             -OutDir $workDir
             NetNat            -OutDir $workDir
             HNSDetail         -OutDir $workDir
+
         }
 
         # Show thread output, and wait for them all to complete
-        $threads | foreach {Show-Thread $_}
+        Show-Threads -Threads $threads
 
         # Tamper Detection
         Sanity            -OutDir $workDir

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -100,9 +100,9 @@ $ExecFunctions = {
 
         ExecCommandText -Command ($Command) -Output $Output
 
-        # Execute Command and redirect to file.  Useful so users know what to run!!!
+        # Execute Command and redirect to file. Useful so users know what to run!!!
         Invoke-Expression $Command | Out-File -Encoding Ascii -Append $Output
-    } #ExecCommandPrivate()
+    } # ExecCommandPrivate()
 
     enum CommandStatus {
         NotTested    # Indicates problem with TestCommand
@@ -117,23 +117,18 @@ $ExecFunctions = {
             [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Command
         )
 
-        $oldGlobalErrorActionPreference = $Global:ErrorActionPreference
-        $result  = [CommandStatus]::NotTested
-        $failure = $null
+        $status = [CommandStatus]::NotTested
+        $output = $null
 
         try {
             # pre-execution cleanup
-            $error.clear()
+            $error.Clear()
 
-            # Instrument the command for silent output
-            $silentCmd = '$({0}) *> $null' -f $Command
+            # Redirect all command output to stdout
+            $silentCmd = '$({0}) *>&1' -f $Command
 
             # ErrorAction MUST be Stop for try catch to work.
-            $Global:ErrorActionPreference = "Stop"
-
-            # Redirect all error output to $null to encompass all possible errors
-            #Write-Host $tmp -ForegroundColor Yellow
-            Invoke-Expression $silentCmd 2> $null
+            $commandOut = (Invoke-Expression $silentCmd -ErrorAction Stop)
             if ($error -ne $null) {
                 # Some PS commands are incorrectly implemented in return code
                 # and require detecting SilentlyContinue
@@ -143,19 +138,18 @@ $ExecFunctions = {
             }
 
             # This is only reachable in success case
-            $result = [CommandStatus]::Succeeded
+            $status = [CommandStatus]::Succeeded
         } catch [Management.Automation.CommandNotFoundException] {
-            $result = [CommandStatus]::Unavailable
+            $status = [CommandStatus]::Unavailable
         } catch {
-            $result  = [CommandStatus]::Failed
-            $failure = $error[0] | Out-String
+            $status  = [CommandStatus]::Failed
+            $commandOut = $error[0] | Out-String
         } finally {
             # post-execution cleanup to avoid false positives
-            $Global:ErrorActionPreference = $oldGlobalErrorActionPreference
-            $error.clear()
+            $error.Clear()
         }
 
-        return $result, $failure
+        return $status, $commandOut
     } # TestCommand()
 
     # Powershell cmdlets have inconsistent implementations in command error handling. This function
@@ -168,25 +162,28 @@ $ExecFunctions = {
             [parameter(Mandatory=$false)] [Switch] $Trusted
         )
 
+        $cmdLog = $Command
+
         if ($Trusted) {
             # Skip command validation
-            Write-Host "$Command"
             ExecCommandPrivate -Command $Command -Output $Output
         } else {
-            $result, $failure = TestCommand -Command $Command
+            $result, $commandOut = TestCommand -Command $Command
 
             if ($result -eq [CommandStatus]::Succeeded) {
-                Write-Host "$Command"
-                ExecCommandPrivate -Command $Command -Output $Output
+                ExecCommandText -Command $Command -Output $Output
+                $commandOut | Out-File -Encoding Ascii -Append $Output
             } else {
-                Write-Host "[Command $result] $Command"
+                $cmdLog = "[Command $result] $Command"
 
                 Write-Output "[Command $result]" | Out-File -Encoding ascii -Append $Output
                 Write-Output "$Command" | Out-File -Encoding ascii -Append $Output
-                Write-Output "$failure" | Out-File -Encoding ascii -Append $Output
+                Write-Output "$commandOut" | Out-File -Encoding ascii -Append $Output
                 Write-Output "`n`n" | Out-File -Encoding ascii -Append $Output
             }
         }
+
+        Write-Host "$cmdLog"
     } # ExecCommand()
 
     function ExecCommands {
@@ -1980,7 +1977,7 @@ function Get-NetView {
     )
 
     $start = Get-Date
-    $version = "2018.09.07.0" # Version within date context
+    $version = "2018.09.14.0" # Version within date context
 
     # Input Validation
     CheckAdminPrivileges $SkipAdminCheck

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -60,7 +60,7 @@ Param(
     [ScriptBlock[]] $ExtraCommands = @(),
 
     [parameter(Mandatory=$false)]
-    [ValidateRange(1, 10)]
+    [ValidateRange(1, 16)]
     [Int] $MaxThreads = 4,
 
     [parameter(Mandatory=$false)]
@@ -277,32 +277,43 @@ function Start-Thread {
 function Show-Threads {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [Hashtable[]] $Threads
+        [parameter(Mandatory=$true)] [Hashtable[]] $Threads,
+        [parameter(Mandatory=$false)] [Switch] $Sequential
     )
 
-    $mThreads = [Collections.ArrayList]$Threads
-
-    while ($mThreads.Count -gt 0) {
-        for ($i = 0; $i -lt $mThreads.Count; $i++) {
-            $thread = $mThreads[$i]
-
-            $thread.Powershell.Streams.Warning | Out-Host
-            $thread.Powershell.Streams.Warning.Clear()
-            $thread.Powershell.Streams.Information | Out-Host
-            $thread.Powershell.Streams.Information.Clear()
-
-            if ($thread.AsyncResult.IsCompleted)
-            {
-                # Accessing Streams.Error blocks until thread is completed
-                $thread.Powershell.Streams.Error | Out-Host
-                $thread.Powershell.Streams.Error.Clear()
-
-                $thread.PowerShell.EndInvoke($thread.AsyncResult)
-                $mThreads.RemoveAt($i)
-                $i--
-            }
+    if ($Sequential) {
+        $Threads | foreach {
+            $_.Powershell.Streams.Error | Out-Host # blocks until thread completion
+            $_.Powershell.Streams.Warning | Out-Host
+            $_.Powershell.Streams.Information | Out-Host
+            $_.PowerShell.Streams.ClearStreams()
+            $_.PowerShell.EndInvoke($_.AsyncResult)   
         }
-        Start-Sleep -Milliseconds 15
+    } else {
+        $mThreads = [Collections.ArrayList]$Threads
+
+        while ($mThreads.Count -gt 0) {
+            for ($i = 0; $i -lt $mThreads.Count; $i++) {
+                $thread = $mThreads[$i]
+
+                $thread.Powershell.Streams.Warning | Out-Host
+                $thread.Powershell.Streams.Warning.Clear()
+                $thread.Powershell.Streams.Information | Out-Host
+                $thread.Powershell.Streams.Information.Clear()
+
+                if ($thread.AsyncResult.IsCompleted)
+                {
+                    # Accessing Streams.Error blocks until thread is completed
+                    $thread.Powershell.Streams.Error | Out-Host
+                    $thread.Powershell.Streams.Error.Clear()
+
+                    $thread.PowerShell.EndInvoke($thread.AsyncResult)
+                    $mThreads.RemoveAt($i)
+                    $i--
+                }
+            }
+            Start-Sleep -Milliseconds 15
+        }
     }
 } # Show-Threads()
 
@@ -1243,7 +1254,7 @@ function VMNetworkAdapterPerVM {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    [Int] $index = 0
+    [Int] $index = 1
     foreach ($vm in TryCmd {Get-VM}) {
         $vmName = $vm.Name
         $vmId   = $vm.VMId
@@ -1360,7 +1371,7 @@ function VMSwitchDetail {
     # See this command to get VFs on vSwitch
     # Get-NetAdapterSriovVf -SwitchId 2
 
-    [Int] $index = 0
+    [Int] $index = 1
     foreach ($vmSwitch in TryCmd {Get-VMSwitch}) {
         $name  = $vmSwitch.Name
         $type  = $vmSwitch.SwitchType
@@ -1754,14 +1765,23 @@ function Counters {
     $file = "CounterDetail" # used with 2 different extensions
     $out  = (Join-Path -Path $dir -ChildPath $file)
     # Get paths for counters of interest
-    $cntrList = @("*Hyper*", "*vfp*", "*ip*", "*udp*", "*tcp*", "*icmp*", "*nat*", "*network*", "*rdma*", "*smb*", "*wfp*", "*Mellanox*", "*intel*")
-    $cntrPaths = Get-Counter -ListSet $cntrList -ErrorAction SilentlyContinue | Sort-Object CounterSetName | ForEach-Object { $_.Paths }
+    # Be careful what you add to this, Get-Counter runtime scales
+    # exponetially with respect to the number of counter instances.
+    $listSet = @("Hyper-V*", "ICMP*", "*Intel*", "IP*", "*Mellanox*", "Network*", "Physical Network", "RDMA*", "SMB*", "TCP*", "UDP*","VFP*", "WFP*", "*WinNAT*")
+    $counterPaths = (Get-Counter -ListSet $listSet -ErrorAction SilentlyContinue | Sort-Object -Unique -Property "CounterSetName").PathsWithInstances
+
+    # Filter counter instances
+    $counterPaths = $counterPaths | where {
+        ($_ -notlike "\Hyper-V Virtual Network Adapter VRSS(*)*") -and `
+        ($_ -notmatch "\\Hyper-V Hypervisor.*Processor\(.*\d+\)")
+    }
 
     Write-Host "Querying perf counters..."
-    $cntrReadings = Get-Counter -Counter $cntrPaths -MaxSamples 5 -SampleInterval 8 -ErrorAction SilentlyContinue
+    $readings = Get-Counter -Counter $counterPaths -MaxSamples 10 -SampleInterval 5 -ErrorAction SilentlyContinue
+
     Write-Host "Exporting perf counters..."
-    $cntrReadings | Export-Counter -Path "$out.blg" -FileFormat BLG
-    $cntrReadings | Export-Counter -Path "$out.csv" -FileFormat CSV
+    $readings | Export-Counter -Path "$out.blg" -FileFormat BLG
+    $readings | Export-Counter -Path "$out.csv" -FileFormat CSV
 } # Counters()
 
 function HwErrorReport {
@@ -2036,7 +2056,7 @@ function Get-NetView {
         [parameter(Mandatory=$false)]
         [ScriptBlock[]] $ExtraCommands = @(),
 
-        [ValidateRange(1, 10)]
+        [ValidateRange(1, 16)]
         [Int] $MaxThreads = 4,
 
         [parameter(Mandatory=$false)]
@@ -2082,7 +2102,6 @@ function Get-NetView {
             NetIp             -OutDir $workDir
             NetNat            -OutDir $workDir
             HNSDetail         -OutDir $workDir
-
         }
 
         # Show thread output, and wait for them all to complete

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -806,7 +806,7 @@ function ChelsioDetail {
     $cxgbtool = Get-Item "$env:windir\System32\cxgbtool.exe" -ErrorAction SilentlyContinue
     if ($cxgbtool.Exists -eq $null) {
         Write-Warning "Unable to collect Chelsio debug logs as cxgbtool is not present in $env:windir\system32"
-        return $null
+        return
     }
 
     $ifName = $NicName
@@ -833,7 +833,7 @@ function ChelsioDetail {
 
         if ([String]::IsNullOrEmpty($ifNameVbd)) {
             Write-Warning "Couldn't resolve interface name for bus device"
-            return $null
+            return
         }
 
         $file = "ChelsioDetail-Cudbg.txt"
@@ -879,7 +879,7 @@ function ChelsioDetail {
 
     if ([String]::IsNullOrEmpty($ifNameNic)) {
         Write-Warning "Couldn't resolve interface name for Network device(ifIndex:$ifIndex)"
-        return $null
+        return
     }
 
     $file = "ChelsioDetail-Debug.txt"
@@ -1516,6 +1516,12 @@ function QosDetail {
 
     $dir = (Join-Path -Path $OutDir -ChildPath "NetQoS")
     New-Item -ItemType directory -Path $dir | Out-Null
+
+    $file = "Get-NetAdapterQos.txt"
+    [String []] $cmds = "Get-NetAdapterQos",
+                        "Get-NetAdapterQos -IncludeHidden | Out-String -Width $columns",
+                        "Get-NetAdapterQos -IncludeHidden | Format-List -Property *"
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetQosDcbxSetting.txt"
     [String []] $cmds = "Get-NetQosDcbxSetting",

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -118,34 +118,36 @@ $ExecFunctions = {
         )
 
         $status = [CommandStatus]::NotTested
-        $commandOut = $null
+        $commandOut = ""
 
         try {
-            # pre-execution cleanup
             $error.Clear()
 
-            # Redirect all command output to stdout
-            $silentCmd = '$({0}) *>&1' -f $Command
+            # Redirect all command output (expect errors) to stdout.
+            # Any errors will still be output to $error variable.
+            $silentCmd = '$({0}) 2>$null 3>&1 4>&1 5>&1 6>&1' -f $Command
 
             # ErrorAction MUST be Stop for try catch to work.
             $commandOut = (Invoke-Expression $silentCmd -ErrorAction Stop)
-            if ($error -ne $null) {
-                # Some PS commands are incorrectly implemented in return code
-                # and require detecting SilentlyContinue
-                if (-not ($silentCmd -like "*SilentlyContinue*")) {
+
+            # Sometimes commands output errors even on successful execution.
+            # We only should fail commands if an error was their *only* output.
+            if (($error -ne $null) -and [String]::IsNullOrWhiteSpace($commandOut)) {
+                # Some PS commands are incorrectly implemented in return
+                # code and require detecting SilentlyContinue
+                if ($Command -notlike "*SilentlyContinue*") {
                     throw $error[0]
                 }
             }
 
-            # This is only reachable in success case
             $status = [CommandStatus]::Succeeded
         } catch [Management.Automation.CommandNotFoundException] {
             $status = [CommandStatus]::Unavailable
         } catch {
             $status  = [CommandStatus]::Failed
-            $commandOut = $error[0] | Out-String
+            $commandOut = ($error[0] | Out-String)
         } finally {
-            # post-execution cleanup to avoid false positives
+            # Post-execution cleanup to avoid false positives
             $error.Clear()
         }
 
@@ -813,8 +815,8 @@ function ChelsioDetail {
     $dirBusName = "BusDev_$($ifHwInfo.Bus)_$($ifHwInfo.Device)_$($ifHwInfo.Function)"
     $dirBus = (Join-Path -Path $dir -ChildPath $dirBusName)
 
-    if ($Global:ChelsioOncePerASIC -notcontains $dirBusName) {
-        $Global:ChelsioOncePerASIC += @($dirBusName) # expensive, avoid duplicate effort
+    if ($Script:ChelsioOncePerASIC -notcontains $dirBusName) {
+        $Script:ChelsioOncePerASIC += @($dirBusName) # expensive, avoid duplicate effort
         New-Item -ItemType Directory -Path $dirBus | Out-Null
 
         # Enumerate VBD
@@ -859,7 +861,7 @@ function ChelsioDetail {
         [String []] $cmds = "cxgbtool.exe $ifNameVbd hardware sgedbg",
                             "cxgbtool.exe $ifNameVbd hardware flash ""$OutFlash"""
         ExecCommandsAsync -OutDir $dirBus -File $file -Commands $cmds
-    } # $Global:ChelsioOncePerASIC
+    } # $Script:ChelsioOncePerASIC
 
     $dirNetName = "NetDev_$ifIndex"
     $dirNet = (Join-Path -Path $dir -ChildPath $dirNetName)

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -350,28 +350,24 @@ function NetIpNic{
     [String []] $cmds = "Get-NetIpAddress -InterfaceAlias ""$name"" | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetIpAddress -InterfaceAlias ""$name"" | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetIpAddress -InterfaceAlias ""$name"" | Format-List",
-                        "Get-NetIpAddress -InterfaceAlias ""$name"" | Format-List -Property *",
-                        "Get-NetIpAddress | Get-Member"
+                        "Get-NetIpAddress -InterfaceAlias ""$name"" | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetIPInterface.txt"
     [String []] $cmds = "Get-NetIPInterface -InterfaceAlias ""$name"" | Out-String -Width $columns",
                         "Get-NetIPInterface -InterfaceAlias ""$name"" | Format-Table -AutoSize",
-                        "Get-NetIPInterface -InterfaceAlias ""$name"" | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetIPInterface | Get-Member"
+                        "Get-NetIPInterface -InterfaceAlias ""$name"" | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetNeighbor.txt"
     [String []] $cmds = "Get-NetNeighbor -InterfaceAlias ""$name"" | Out-String -Width $columns",
                         "Get-NetNeighbor -InterfaceAlias ""$name"" | Format-Table -AutoSize | Out-String -Width $columns",
-                        "Get-NetNeighbor -InterfaceAlias ""$name"" | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetNeighbor | Get-Member"
+                        "Get-NetNeighbor -InterfaceAlias ""$name"" | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetRoute.txt"
     [String []] $cmds = "Get-NetRoute -InterfaceAlias ""$name"" | Format-Table -AutoSize | Out-String -Width $columns",
-                        "Get-NetRoute -InterfaceAlias ""$name"" | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetRoute | Get-Member"
+                        "Get-NetRoute -InterfaceAlias ""$name"" | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # NetIpNic()
 
@@ -388,87 +384,74 @@ function NetIp {
     [String []] $cmds = "Get-NetIpAddress | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetIpAddress | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetIpAddress | Format-List",
-                        "Get-NetIpAddress | Format-List -Property *",
-                        "Get-NetIpAddress | Get-Member"
+                        "Get-NetIpAddress | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetIPInterface.txt"
     [String []] $cmds = "Get-NetIPInterface | Out-String -Width $columns",
                         "Get-NetIPInterface | Format-Table -AutoSize  | Out-String -Width $columns",
-                        "Get-NetIPInterface | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetIPInterface | Get-Member"
+                        "Get-NetIPInterface | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetNeighbor.txt"
     [String []] $cmds = "Get-NetNeighbor | Format-Table -AutoSize | Out-String -Width $columns",
-                        "Get-NetNeighbor | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetNeighbor | Get-Member"
+                        "Get-NetNeighbor | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetIPv4Protocol.txt"
     [String []] $cmds = "Get-NetIPv4Protocol | Out-String -Width $columns",
                         "Get-NetIPv4Protocol | Format-List  -Property *",
                         "Get-NetIPv4Protocol | Format-Table -Property * -AutoSize",
-                        "Get-NetIPv4Protocol | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetIPv4Protocol | Get-Member"
+                        "Get-NetIPv4Protocol | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetIPv6Protocol.txt"
     [String []] $cmds = "Get-NetIPv6Protocol | Out-String -Width $columns",
                         "Get-NetIPv6Protocol | Format-List  -Property *",
                         "Get-NetIPv6Protocol | Format-Table -Property * -AutoSize",
-                        "Get-NetIPv6Protocol | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetIPv6Protocol | Get-Member"
+                        "Get-NetIPv6Protocol | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetOffloadGlobalSetting.txt"
     [String []] $cmds = "Get-NetOffloadGlobalSetting | Out-String -Width $columns",
                         "Get-NetOffloadGlobalSetting | Format-List  -Property *",
                         "Get-NetOffloadGlobalSetting | Format-Table -AutoSize",
-                        "Get-NetOffloadGlobalSetting | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetOffloadGlobalSetting | Get-Member"
+                        "Get-NetOffloadGlobalSetting | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetPrefixPolicy.txt"
     [String []] $cmds = "Get-NetPrefixPolicy | Format-Table -AutoSize",
-                        "Get-NetPrefixPolicy | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetPrefixPolicy | Get-Member"
+                        "Get-NetPrefixPolicy | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetRoute.txt"
     [String []] $cmds = "Get-NetRoute | Format-Table -AutoSize",
-                        "Get-NetRoute | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetRoute | Get-Member"
+                        "Get-NetRoute | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetTCPConnection.txt"
     [String []] $cmds = "Get-NetTCPConnection | Format-Table -AutoSize",
-                        "Get-NetTCPConnection | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetTCPConnection | Get-Member"
+                        "Get-NetTCPConnection | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -Trusted -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetTcpSetting.txt"
     [String []] $cmds = "Get-NetTcpSetting  | Format-Table -AutoSize",
-                        "Get-NetTcpSetting  | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetTcpSetting  | Get-Member"
+                        "Get-NetTcpSetting  | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -Trusted -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetTransportFilter.txt"
     [String []] $cmds = "Get-NetTransportFilter  | Format-Table -AutoSize",
-                        "Get-NetTransportFilter  | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetTransportFilter  | Get-Member"
+                        "Get-NetTransportFilter  | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetUDPEndpoint.txt"
     [String []] $cmds = "Get-NetUDPEndpoint  | Format-Table -AutoSize",
-                        "Get-NetUDPEndpoint  | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetUDPEndpoint  | Get-Member"
+                        "Get-NetUDPEndpoint  | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetUDPSetting.txt"
     [String []] $cmds = "Get-NetUDPSetting  | Format-Table -AutoSize",
-                        "Get-NetUDPSetting  | Format-Table -Property * -AutoSize | Out-String -Width $columns",
-                        "Get-NetUDPSetting  | Get-Member"
+                        "Get-NetUDPSetting  | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # NetIp()
 
@@ -485,40 +468,35 @@ function NetNat {
     [String []] $cmds = "Get-NetNat | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetNat | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetNat | Format-List",
-                        "Get-NetNat | Format-List -Property *",
-                        "Get-NetNat | Get-Member"
+                        "Get-NetNat | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetNatExternalAddress.txt"
     [String []] $cmds = "Get-NetNatExternalAddress | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetNatExternalAddress | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetNatExternalAddress | Format-List",
-                        "Get-NetNatExternalAddress | Format-List -Property *",
-                        "Get-NetNatExternalAddress | Get-Member"
+                        "Get-NetNatExternalAddress | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetNatGlobal.txt"
     [String []] $cmds = "Get-NetNatGlobal | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetNatGlobal | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetNatGlobal | Format-List",
-                        "Get-NetNatGlobal | Format-List -Property *",
-                        "Get-NetNatGlobal | Get-Member"
+                        "Get-NetNatGlobal | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetNatSession.txt"
     [String []] $cmds = "Get-NetNatSession | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetNatSession | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetNatSession | Format-List",
-                        "Get-NetNatSession | Format-List -Property *",
-                        "Get-NetNatSession | Get-Member"
+                        "Get-NetNatSession | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetNatStaticMapping.txt"
     [String []] $cmds = "Get-NetNatStaticMapping | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetNatStaticMapping | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetNatStaticMapping | Format-List",
-                        "Get-NetNatStaticMapping | Format-List -Property *",
-                        "Get-NetNatStaticMapping | Get-Member"
+                        "Get-NetNatStaticMapping | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
 } # NetNat()
@@ -535,124 +513,104 @@ function NetAdapterWorker {
 
     $file = "Get-NetAdapter.txt"
     [String []] $cmds = "Get-NetAdapter -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapter -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapter | Get-Member"
+                        "Get-NetAdapter -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterAdvancedProperty.txt"
     [String []] $cmds = "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties | Sort-Object RegistryKeyword | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties -IncludeHidden | Sort-Object RegistryKeyword | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties -IncludeHidden | Format-Table  -Property * | Out-String -Width $columns",
-                        "Get-NetAdapterAdvancedProperty | Get-Member"
+                        "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties -IncludeHidden | Format-Table  -Property * | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterBinding.txt"
     [String []] $cmds = "Get-NetAdapterBinding -Name ""$name"" -AllBindings -IncludeHidden | Sort-Object ComponentID | Out-String -Width $columns",
-                        "Get-NetAdapterBinding -Name ""$name"" -AllBindings -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterBinding | Get-Member"
+                        "Get-NetAdapterBinding -Name ""$name"" -AllBindings -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterChecksumOffload.txt"
     [String []] $cmds = "Get-NetAdapterChecksumOffload -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterChecksumOffload -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterChecksumOffload | Get-Member"
+                        "Get-NetAdapterChecksumOffload -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterLso.txt"
     [String []] $cmds = "Get-NetAdapterLso -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterLso -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterLso | Get-Member"
+                        "Get-NetAdapterLso -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterRss.txt"
     [String []] $cmds = "Get-NetAdapterRss -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterRss -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterRss | Get-Member"
+                        "Get-NetAdapterRss -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterStatistics.txt"
     [String []] $cmds = "Get-NetAdapterStatistics -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterStatistics -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterStatistics | Get-Member"
+                        "Get-NetAdapterStatistics -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterEncapsulatedPacketTaskOffload.txt"
     [String []] $cmds = "Get-NetAdapterEncapsulatedPacketTaskOffload -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterEncapsulatedPacketTaskOffload -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterEncapsulatedPacketTaskOffload | Get-Member"
+                        "Get-NetAdapterEncapsulatedPacketTaskOffload -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterHardwareInfo.txt"
     [String []] $cmds = "Get-NetAdapterHardwareInfo -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterHardwareInfo -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterHardwareInfo | Get-Member"
+                        "Get-NetAdapterHardwareInfo -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterIPsecOffload.txt"
     [String []] $cmds = "Get-NetAdapterIPsecOffload -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterIPsecOffload -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterIPsecOffload | Get-Member"
+                        "Get-NetAdapterIPsecOffload -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterPowerManagement.txt"
     [String []] $cmds = "Get-NetAdapterPowerManagement -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterPowerManagement -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterPowerManagement | Get-Member"
+                        "Get-NetAdapterPowerManagement -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterQos.txt"
     [String []] $cmds = "Get-NetAdapterQos -Name ""$name"" -IncludeHidden -ErrorAction SilentlyContinue | Out-String -Width $columns",
-                        "Get-NetAdapterQos -Name ""$name"" -IncludeHidden -ErrorAction SilentlyContinue | Format-List  -Property *",
-                        "Get-NetAdapterQos | Get-Member"
+                        "Get-NetAdapterQos -Name ""$name"" -IncludeHidden -ErrorAction SilentlyContinue | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterRdma.txt"
     [String []] $cmds = "Get-NetAdapterRdma -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterRdma -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterRdma | Get-Member"
+                        "Get-NetAdapterRdma -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterPacketDirect.txt"
     [String []] $cmds = "Get-NetAdapterPacketDirect -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterPacketDirect -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterPacketDirect | Get-Member"
+                        "Get-NetAdapterPacketDirect -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterRsc.txt"
     [String []] $cmds = "Get-NetAdapterRsc -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterRsc -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterRsc | Get-Member"
+                        "Get-NetAdapterRsc -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterSriov.txt"
     [String []] $cmds = "Get-NetAdapterSriov -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterSriov -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterSriov | Get-Member"
+                        "Get-NetAdapterSriov -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterSriovVf.txt"
     [String []] $cmds = "Get-NetAdapterSriovVf -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterSriovVf -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterSriovVf | Get-Member"
+                        "Get-NetAdapterSriovVf -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterVmq.txt"
     [String []] $cmds = "Get-NetAdapterVmq -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterVmq -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterVmq | Get-Member"
+                        "Get-NetAdapterVmq -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterVmqQueue.txt"
     [String []] $cmds = "Get-NetAdapterVmqQueue -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterVmqQueue -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterVmqQueue | Get-Member"
+                        "Get-NetAdapterVmqQueue -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterVPort.txt"
     [String []] $cmds = "Get-NetAdapterVPort -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
-                        "Get-NetAdapterVPort -Name ""$name"" -IncludeHidden | Format-List  -Property *",
-                        "Get-NetAdapterVPort | Get-Member"
+                        "Get-NetAdapterVPort -Name ""$name"" -IncludeHidden | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # NetAdapterWorker()
 
@@ -694,20 +652,17 @@ function LbfoWorker {
     Write-Host "Processing: $title"
     $file = "Get-NetLbfoTeam.txt"
     [String []] $cmds = "Get-NetLbfoTeam -Name ""$name""",
-                        "Get-NetLbfoTeam -Name ""$name"" | Format-List  -Property *",
-                        "Get-NetLbfoTeam | Get-Member"
+                        "Get-NetLbfoTeam -Name ""$name"" | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetLbfoTeamNic.txt"
     [String []] $cmds = "Get-NetLbfoTeamNic -Team ""$name""",
-                        "Get-NetLbfoTeamNic -Team ""$name"" | Format-List  -Property *",
-                        "Get-NetLbfoTeamNic | Get-Member"
+                        "Get-NetLbfoTeamNic -Team ""$name"" | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetLbfoTeamMember.txt"
     [String []] $cmds = "Get-NetLbfoTeamMember -Team ""$name""",
-                        "Get-NetLbfoTeamMember -Team ""$name"" | Format-List  -Property *",
-                        "Get-NetLbfoTeamMember | Get-Member"
+                        "Get-NetLbfoTeamMember -Team ""$name"" | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     # Report the TNIC(S)
@@ -1016,50 +971,42 @@ function HostVNicWorker {
 
     $file = "Get-VMNetworkAdapter.txt"
     [String []] $cmds = "Get-VMNetworkAdapter -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapter -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *",
-                        "Get-VMNetworkAdapter -ManagementOS| Get-Member"
+                        "Get-VMNetworkAdapter -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterAcl.txt"
     [String []] $cmds = "Get-VMNetworkAdapterAcl -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterAcl -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *",
-                        "Get-VMNetworkAdapterAcl -ManagementOS | Get-Member"
+                        "Get-VMNetworkAdapterAcl -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterExtendedAcl.txt"
     [String []] $cmds = "Get-VMNetworkAdapterExtendedAcl -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterExtendedAcl -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *",
-                        "Get-VMNetworkAdapterExtendedAcl -ManagementOS | Get-Member"
+                        "Get-VMNetworkAdapterExtendedAcl -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterFailoverConfiguration.txt"
     [String []] $cmds = "Get-VMNetworkAdapterFailoverConfiguration -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterFailoverConfiguration -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *",
-                        "Get-VMNetworkAdapterFailoverConfiguration -ManagementOS | Get-Member"
+                        "Get-VMNetworkAdapterFailoverConfiguration -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterIsolation.txt"
     [String []] $cmds = "Get-VMNetworkAdapterIsolation -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterIsolation -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *",
-                        "Get-VMNetworkAdapterIsolation -ManagementOS | Get-Member"
+                        "Get-VMNetworkAdapterIsolation -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterRoutingDomainMapping.txt"
     [String []] $cmds = "Get-VMNetworkAdapterRoutingDomainMapping -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterRoutingDomainMapping -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List -Property *",
-                        "Get-VMNetworkAdapterRoutingDomainMapping -ManagementOS | Get-Member"
+                        "Get-VMNetworkAdapterRoutingDomainMapping -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterTeamMapping.txt"
     [String []] $cmds = "Get-VMNetworkAdapterTeamMapping -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterTeamMapping -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *",
-                        "Get-VMNetworkAdapterTeamMapping -ManagementOS | Get-Member"
+                        "Get-VMNetworkAdapterTeamMapping -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterVlan.txt"
     [String []] $cmds = "Get-VMNetworkAdapterVlan -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterVlan -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *",
-                        "Get-VMNetworkAdapterVlan -ManagementOS | Get-Member"
+                        "Get-VMNetworkAdapterVlan -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # HostVNicWorker()
 
@@ -1129,60 +1076,50 @@ function VMNetworkAdapterDetail {
     Write-Host "Processing: $title"
     $file = "Get-VMNetworkAdapter.txt"
     [String []] $cmds = "$vmNicObject | Out-String -Width $columns",
-                        "$vmNicObject | Format-List -Property *",
-                        "$vmNicObject | Get-Member"
+                        "$vmNicObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterAcl.txt"
     [String []] $cmds = "Get-VMNetworkAdapterAcl -VMNetworkAdpater $vmNicObject | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterAcl -VMNetworkAdapter $vmNicObject | Format-List -Property *",
-                        "Get-VMNetworkAdapterAcl | Get-Member"
+                        "Get-VMNetworkAdapterAcl -VMNetworkAdapter $vmNicObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterExtendedAcl.txt"
     [String []] $cmds = "Get-VMNetworkAdapterExtendedAcl -VMNetworkAdapter $vmNicObject | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterExtendedAcl -VMNetworkAdapter $vmNicObject | Format-List -Property *",
-                        "Get-VMNetworkAdapterExtendedAcl | Get-Member"
+                        "Get-VMNetworkAdapterExtendedAcl -VMNetworkAdapter $vmNicObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterFailoverConfiguration.txt"
     [String []] $cmds = "Get-VMNetworkAdapterFailoverConfiguration -VMNetworkAdapter $vmNicObject | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterFailoverConfiguration -VMNetworkAdapter $vmNicObject | Format-List -Property *",
-                        "Get-VMNetworkAdapterFailoverConfiguration | Get-Member"
+                        "Get-VMNetworkAdapterFailoverConfiguration -VMNetworkAdapter $vmNicObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterIsolation.txt"
     [String []] $cmds = "Get-VMNetworkAdapterIsolation -VMNetworkAdapter $vmNicObject | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterIsolation -VMNetworkAdapter $vmNicObject | Format-List -Property *",
-                        "Get-VMNetworkAdapterIsolation | Get-Member"
+                        "Get-VMNetworkAdapterIsolation -VMNetworkAdapter $vmNicObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterRoutingDomainMapping.txt"
     [String []] $cmds = "Get-VMNetworkAdapterRoutingDomainMapping -VMNetworkAdapter $vmNicObject | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterRoutingDomainMapping -VMNetworkAdapter $vmNicObject | Format-List -Property *",
-                        "Get-VMNetworkAdapterRoutingDomainMapping | Get-Member"
+                        "Get-VMNetworkAdapterRoutingDomainMapping -VMNetworkAdapter $vmNicObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterTeamMapping.txt"
     [String []] $cmds = "Get-VMNetworkAdapterTeamMapping -VMNetworkAdapter $vmNicObject | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterTeamMapping -VMNetworkAdapter $vmNicObject | Format-List -Property *",
-                        "Get-VMNetworkAdapterTeamMapping | Get-Member"
+                        "Get-VMNetworkAdapterTeamMapping -VMNetworkAdapter $vmNicObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterVlan.txt"
     [String []] $cmds = "Get-VMNetworkAdapterVlan -VMNetworkAdapter $vmNicObject | Out-String -Width $columns",
-                        "Get-VMNetworkAdapterVlan -VMNetworkAdapter $vmNicObject | Format-List -Property *",
-                        "Get-VMNetworkAdapterVlan | Get-Member"
+                        "Get-VMNetworkAdapterVlan -VMNetworkAdapter $vmNicObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchExtensionPortFeature.txt"
-    [String []] $cmds = "Get-VMSwitchExtensionPortFeature -VMNetworkAdapter $vmNicObject | Format-List -Property *",
-                        "Get-VMSwitchExtensionPortFeature | Get-Member"
+    [String []] $cmds = "Get-VMSwitchExtensionPortFeature -VMNetworkAdapter $vmNicObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchExtensionPortData.txt"
-    [String []] $cmds = "Get-VMSwitchExtensionPortData -VMNetworkAdapter $vmNicObject | Format-List -Property *",
-                        "Get-VMSwitchExtensionPortData | Get-Member"
+    [String []] $cmds = "Get-VMSwitchExtensionPortData -VMNetworkAdapter $vmNicObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
     #>
 } # VMNetworkAdapterDetail()
@@ -1202,8 +1139,7 @@ function VMWorker {
 
     $file = "Get-VM.txt"
     [String []] $cmds = "$vmObject | Out-String -Width $columns",
-                        "$vmObject | Format-List -Property *",
-                        "$vmObject | Get-Member"
+                        "$vmObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMBios.txt"
@@ -1295,28 +1231,23 @@ function VMSwitchWorker {
 
     $file = "Get-VMSwitch.txt"
     [String []] $cmds = "$vmSwitchObject",
-                        "$vmSwitchObject | Format-List -Property *",
-                        "$vmSwitchObject | Get-Member"
+                        "$vmSwitchObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchExtension.txt"
-    [String []] $cmds = "Get-VMSwitchExtension -VMSwitch $vmSwitchObject | Format-List -Property *",
-                        "Get-VMSwitchExtension -VMSwitch $vmSwitchObject | Get-Member"
+    [String []] $cmds = "Get-VMSwitchExtension -VMSwitch $vmSwitchObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchExtensionSwitchData.txt"
-    [String []] $cmds = "Get-VMSwitchExtensionSwitchData -VMSwitch $vmSwitchObject | Format-List -Property *",
-                        "Get-VMSwitchExtensionSwitchData -VMSwitch $vmSwitchObject | Get-Member"
+    [String []] $cmds = "Get-VMSwitchExtensionSwitchData -VMSwitch $vmSwitchObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchExtensionSwitchFeature.txt"
-    [String []] $cmds = "Get-VMSwitchExtensionSwitchFeature -VMSwitch $vmSwitchObject | Format-List -Property *",
-                        "Get-VMSwitchExtensionSwitchFeature -VMSwitch $vmSwitchObject | Get-Member"
+    [String []] $cmds = "Get-VMSwitchExtensionSwitchFeature -VMSwitch $vmSwitchObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchTeam.txt"
-    [String []] $cmds = "Get-VMSwitchTeam -VMSwitch $vmSwitchObject | Format-List -Property *",
-                        "Get-VMSwitchTeam | Get-Member"
+    [String []] $cmds = "Get-VMSwitchTeam -VMSwitch $vmSwitchObject | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # VMSwitchWorker()
 
@@ -1411,14 +1342,12 @@ function NetworkSummary {
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSystemSwitchExtension.txt"
-    [String []] $cmds = "Get-VMSystemSwitchExtension | Format-List -Property *",
-                        "Get-VMSystemSwitchExtension | Get-Member"
+    [String []] $cmds = "Get-VMSystemSwitchExtension | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSystemSwitchExtensionSwitchFeature.txt"
     [String []] $cmds = "Get-VMSystemSwitchExtensionSwitchFeature",
-                        "Get-VMSystemSwitchExtensionSwitchFeature | Format-List -Property *",
-                        "Get-VMSystemSwitchExtensionSwitchFeature | Get-Member"
+                        "Get-VMSystemSwitchExtensionSwitchFeature | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapter.txt"
@@ -1458,32 +1387,27 @@ function SMBDetail {
 
     $file = "Get-SmbClientNetworkInterface.txt"
     [String []] $cmds = "Get-SmbClientNetworkInterface | Sort-Object FriendlyName | Format-Table -AutoSize | Out-String -Width $columns",
-                        "Get-SmbClientNetworkInterface | Format-List  -Property *",
-                        "Get-SmbClientNetworkInterface | Get-Member"
+                        "Get-SmbClientNetworkInterface | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-SmbServerNetworkInterface.txt"
     [String []] $cmds = "Get-SmbServerNetworkInterface | Sort-Object FriendlyName | Format-Table -AutoSize | Out-String -Width $columns",
-                        "Get-SmbServerNetworkInterface | Format-List  -Property *",
-                        "Get-SmbServerNetworkInterface | Get-Member"
+                        "Get-SmbServerNetworkInterface | Format-List  -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-SmbClientConfiguration.txt"
-    [String []] $cmds = "Get-SmbClientConfiguration",
-                        "Get-SmbClientConfiguration | Get-Member"
+    [String []] $cmds = "Get-SmbClientConfiguration"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-SmbMultichannelConnection.txt"
     [String []] $cmds = "Get-SmbMultichannelConnection | Sort-Object Name | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-SmbMultichannelConnection -IncludeNotSelected | Format-List -Property *",
                         "Get-SmbMultichannelConnection -SmbInstance CSV -IncludeNotSelected | Format-List -Property *",
-                        "Get-SmbMultichannelConnection -SmbInstance SBL -IncludeNotSelected | Format-List -Property *",
-                        "Get-SmbMultichannelConnection | Get-Member"
+                        "Get-SmbMultichannelConnection -SmbInstance SBL -IncludeNotSelected | Format-List -Property *"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-SmbMultichannelConstraint.txt"
-    [String []] $cmds = "Get-SmbMultichannelConstraint",
-                        "Get-SmbMultichannelConstraint | Get-Member"
+    [String []] $cmds = "Get-SmbMultichannelConstraint"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Smb-WindowsEvents.txt"
@@ -1541,13 +1465,11 @@ function HNSDetail {
     ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-HNSNetwork-1.txt"
-    [String []] $cmds = "Get-HNSNetwork | ConvertTo-Json -Depth 10",
-                        "Get-HNSNetwork | Get-Member"
+    [String []] $cmds = "Get-HNSNetwork | ConvertTo-Json -Depth 10"
     ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-HNSEndpoint-1.txt"
-    [String []] $cmds = "Get-HNSEndpoint | ConvertTo-Json -Depth 10",
-                        "Get-HNSEndpoint | Get-Member"
+    [String []] $cmds = "Get-HNSEndpoint | ConvertTo-Json -Depth 10"
     ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     # HNS service stop -> start occurs after capturing the current HNS state info.
@@ -1575,13 +1497,11 @@ function HNSDetail {
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-HNSNetwork-2.txt"
-    [String []] $cmds = "Get-HNSNetwork | ConvertTo-Json -Depth 10",
-                        "Get-HNSNetwork | Get-Member"
+    [String []] $cmds = "Get-HNSNetwork | ConvertTo-Json -Depth 10"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-HNSEndpoint-2.txt"
-    [String []] $cmds = "Get-HNSEndpoint | ConvertTo-Json -Depth 10",
-                        "Get-HNSEndpoint | Get-Member"
+    [String []] $cmds = "Get-HNSEndpoint | ConvertTo-Json -Depth 10"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     #netsh trace start scenario=Virtualization provider=Microsoft-Windows-tcpip provider=Microsoft-Windows-winnat capture=yes captureMultilayer=yes capturetype=both report=disabled tracefile=$dir\server.etl overwrite=yes
@@ -1601,29 +1521,25 @@ function QosDetail {
     $file = "Get-NetQosDcbxSetting.txt"
     [String []] $cmds = "Get-NetQosDcbxSetting",
                         "Get-NetQosDcbxSetting | Format-List  -Property *",
-                        "Get-NetQosDcbxSetting | Format-Table -Property *  -AutoSize | Out-String -Width $columns",
-                        "Get-NetQosDcbxSetting | Get-Member"
+                        "Get-NetQosDcbxSetting | Format-Table -Property *  -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetQosFlowControl.txt"
     [String []] $cmds = "Get-NetQosFlowControl",
                         "Get-NetQosFlowControl | Format-List  -Property *",
-                        "Get-NetQosFlowControl | Format-Table -Property *  -AutoSize | Out-String -Width $columns",
-                        "Get-NetQosFlowControl | Get-Member"
+                        "Get-NetQosFlowControl | Format-Table -Property *  -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetQosPolicy.txt"
     [String []] $cmds = "Get-NetQosPolicy",
                         "Get-NetQosPolicy | Format-List  -Property *",
-                        "Get-NetQosPolicy | Format-Table -Property *  -AutoSize | Out-String -Width $columns",
-                        "Get-NetQosPolicy | Get-Member"
+                        "Get-NetQosPolicy | Format-Table -Property *  -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetQosTrafficClass.txt"
     [String []] $cmds = "Get-NetQosTrafficClass",
                         "Get-NetQosTrafficClass | Format-List  -Property *",
-                        "Get-NetQosTrafficClass | Format-Table -Property *  -AutoSize | Out-String -Width $columns",
-                        "Get-NetQosTrafficClass | Get-Member"
+                        "Get-NetQosTrafficClass | Format-Table -Property *  -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # QosDetail()
 

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -118,7 +118,7 @@ $ExecFunctions = {
         )
 
         $status = [CommandStatus]::NotTested
-        $output = $null
+        $commandOut = $null
 
         try {
             # pre-execution cleanup

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -296,7 +296,7 @@ function StreamThread {
 # Data Collection Functions
 #
 
-function NetIpNicWorker {
+function NetIpNic{
     [CmdletBinding()]
     Param(
         [parameter(Mandatory=$true)] [String] $NicName,
@@ -304,7 +304,8 @@ function NetIpNicWorker {
     )
 
     $name = $NicName
-    $dir  = $OutDir
+    $dir  = (Join-Path -Path $OutDir -ChildPath "NetIp")
+    New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "Get-NetIpAddress.txt"
     $out  = (Join-Path -Path $dir -ChildPath $file)
@@ -345,29 +346,16 @@ function NetIpNicWorker {
     ForEach($cmd in $cmds) {
         ExecCommand -Command ($cmd) -Output $out
     }
-} # NetIpNicWorker()
-
-function NetIpNic {
-    [CmdletBinding()]
-    Param(
-         [parameter(Mandatory=$true)] [String] $NicName,
-         [parameter(Mandatory=$true)] [String] $OutDir
-    )
-
-    $name = $NicName
-
-    $dir    = (Join-Path -Path $OutDir -ChildPath ("NetIp"))
-    New-Item -ItemType directory -Path $dir | Out-Null
-    NetIpNicWorker  -NicName $name -OutDir $dir
 } # NetIpNic()
 
-function NetIpWorker {
+function NetIp {
     [CmdletBinding()]
     Param(
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $dir  = $OutDir
+    $dir    = (Join-Path -Path $OutDir -ChildPath "NetIp")
+    New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "Get-NetIpAddress.txt"
     $out  = (Join-Path -Path $dir -ChildPath $file)
@@ -494,26 +482,16 @@ function NetIpWorker {
     ForEach($cmd in $cmds) {
         ExecCommand -Command ($cmd) -Output $out
     }
-} # NetIpWorker()
-
-function NetIp {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [String] $OutDir
-    )
-
-    $dir    = (Join-Path -Path $OutDir -ChildPath ("NetIp"))
-    New-Item -ItemType directory -Path $dir | Out-Null
-    NetIpWorker -OutDir $dir
 } # NetIp()
 
-function NetNatWorker {
+function NetNat {
     [CmdletBinding()]
     Param(
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $dir  = $OutDir
+    $dir = (Join-Path -Path $OutDir -ChildPath "NetNat")
+    New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "Get-NetNat.txt"
     $out  = (Join-Path -Path $dir -ChildPath $file)
@@ -570,17 +548,6 @@ function NetNatWorker {
         ExecCommand -Command ($cmd) -Output $out
     }
 
-} # NetNatWorker
-
-function NetNat {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [String] $OutDir
-    )
-
-    $dir    = (Join-Path -Path $OutDir -ChildPath ("NetNat"))
-    New-Item -ItemType directory -Path $dir | Out-Null
-    NetNatWorker -OutDir $dir
 } # NetNat()
 
 function NetAdapterWorker {
@@ -805,7 +772,6 @@ function NetAdapterWorkerPrepare {
     NicVendor        -NicName $name -OutDir $dir
 } # NetAdapterWorkerPrepare()
 
-
 function LbfoWorker {
     [CmdletBinding()]
     Param(
@@ -813,10 +779,13 @@ function LbfoWorker {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    # Normalize Names
+    # Normalize Variable
     $name = $LbfoName
-    $out  = $OutDir
+    $dir  = (Join-Path -Path $OutDir -ChildPath ("LBFO.$name"))
+    New-Item -ItemType directory -Path $dir | Out-Null
 
+    Write-Host "Processing: $name"
+    Write-Host "----------------------------------------------"
     $file = "Get-NetLbfoTeam.txt"
     $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetLbfoTeam -Name ""$name""",
@@ -855,24 +824,6 @@ function LbfoWorker {
     }
 } # LbfoWorker()
 
-function LbfoWorkerPrepare {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [String] $LbfoName,
-        [parameter(Mandatory=$true)] [String] $OutDir
-    )
-
-    # Normalize Variable
-    $name = $LbfoName
-
-    $dir  = (Join-Path -Path $OutDir -ChildPath ("LBFO.$name"))
-    New-Item -ItemType directory -Path $dir | Out-Null
-
-    Write-Host "Processing: $name"
-    Write-Host "----------------------------------------------"
-    LbfoWorker -LbfoName $name -OutDir $dir
-} # LbfoWorkerPrepare()
-
 function LbfoDetail {
     [CmdletBinding()]
     Param(
@@ -897,7 +848,7 @@ function LbfoDetail {
         }
 
         if (-not $match) {
-            LbfoWorkerPrepare -LbfoName $name -OutDir $out
+            LbfoWorker -LbfoName $name -OutDir $out
         }
     }
 } # LbfoDetail()
@@ -916,7 +867,7 @@ function ProtocolNicDetail {
     foreach ($desc in TryCmd {(Get-VMSwitch -Name "$VMSwitchName").NetAdapterInterfaceDescriptions}) {
         $nic = Get-NetAdapter -InterfaceDescription $desc
         if ($nic.DriverFileName -like "NdisImPlatform.sys") {
-            LbfoWorkerPrepare -LbfoName $nic.Name -OutDir $out
+            LbfoWorker -LbfoName $nic.Name -OutDir $out
         } else {
             NetAdapterWorkerPrepare -NicDesc $desc -OutDir $out
         }
@@ -1305,19 +1256,22 @@ function HostVNicDetail {
     }
 } # HostVNicDetail()
 
-
-function VMNetworkAdapterWorker {
+function VMNetworkAdapterDetail {
     [CmdletBinding()]
     Param(
         [parameter(Mandatory=$true)] [String] $VMName,
-        [parameter(Mandatory=$true)] [String] $VMNicName,
+        [parameter(Mandatory=$true)] [String] $VmNicName,
+        [parameter(Mandatory=$true)] [String] $VMNicMac,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    # Normalize Names
     $name = $VMNicName
-    $dir  = $OutDir
+    $title = "VMNic.$VmNicName.$VMNicMac"
+    $dir  = (Join-Path -Path $OutDir -ChildPath $title)
+    New-Item -ItemType directory -Path $dir | Out-Null
 
+    Write-Host "Processing: $title"
+    Write-Host "--------------------------------------"
     $file = "Get-VMNetworkAdapter.txt"
     $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapter -Name ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
@@ -1389,24 +1343,7 @@ function VMNetworkAdapterWorker {
     ForEach($cmd in $cmds) {
         ExecCommand -Command ($cmd) -Output $out
     }
-} # VMNetworkAdapterWorker()
-
-function VmNetworkAdapterDetail {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [String] $VMName,
-        [parameter(Mandatory=$true)] [String] $VmNicName,
-        [parameter(Mandatory=$true)] [String] $VmNicMac,
-        [parameter(Mandatory=$true)] [String] $OutDir
-    )
-
-    $dir     = (Join-Path -Path $OutDir -ChildPath ("VMNic.$VmNicName.$VmNicMac"))
-    New-Item -ItemType directory -Path $dir | Out-Null
-
-    Write-Host "Processing: VMNic.$VmNicName.$VmNicMac"
-    Write-Host "--------------------------------------"
-    VMNetworkAdapterWorker -VMName $VMName -VMNicName $VmNicName -OutDir $dir
-} # VmNetworkAdapterDetail()
+} # VMNetworkAdapterDetail()
 
 function VmWorker {
     [CmdletBinding()]
@@ -1614,7 +1551,7 @@ function VMSwitchWorker {
     #>
 } # VMSwitchWorker()
 
-function VfpExtensionWorker {
+function VfpExtensionDetail {
     [CmdletBinding()]
     Param(
         [parameter(Mandatory=$true)] [String] $VMSwitchName,
@@ -1622,26 +1559,30 @@ function VfpExtensionWorker {
     )
 
     $name = $VMSwitchName
-    $out  = $OutDir
+    $vfpExtension = TryCmd {Get-VMSwitch -Name $name | Get-VMSwitchExtension} | where {$_.Name -like "Microsoft Azure VFP Switch Extension"}
 
-    $dir  = (Join-Path -Path $out -ChildPath ("VFP"))
+    if ($vfpExtension.Enabled -ne "True") {
+        return
+    }
+
+    $dir  = (Join-Path -Path $OutDir -ChildPath "VFP")
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "VfpCtrl.help.txt"
     $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "vfpctrl.exe /h"
-    ForEach($cmd in $cmds) {
+    foreach ($cmd in $cmds) {
         ExecCommand -Command ($cmd) -Output $out
     }
 
-
-    $switches = Get-WmiObject -Namespace root\virtualization\v2 -Class Msvm_VirtualEthernetSwitch
-    foreach ($switch in $switches) {
-        if ($switch.ElementName -eq $name) {
-            $currswitch = $switch
+    $switches = Get-WmiObject -Namespace "root\virtualization\v2" -Class "Msvm_VirtualEthernetSwitch"
+    foreach ($vSwitch in $switches) {
+        if ($vSwitch.ElementName -eq $name) {
+            $currswitch = $vSwitch
             break
         }
     }
+
     $ports = $currswitch.GetRelated("Msvm_EthernetSwitchPort", "Msvm_SystemDevice", $null, $null, $null, $null, $false, $null)
     foreach ($port in $ports) {
         $portGuid = $port.Name
@@ -1651,29 +1592,10 @@ function VfpExtensionWorker {
                             "vfpctrl.exe /list-mapping /port $portGuid",
                             "vfpctrl.exe /list-rule /port $portGuid",
                             "vfpctrl.exe /port $portGuid /get-port-state"
-        ForEach($cmd in $cmds) {
+        foreach ($cmd in $cmds) {
             ExecCommand -Command ($cmd) -Output $out
         }
     }
-
-} # VfpExtensionWorker()
-
-function VfpExtensionDetail {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [String] $VMSwitchName,
-        [parameter(Mandatory=$true)] [String] $OutDir
-    )
-
-    $name = $VMSwitchName
-    $out  = $OutDir
-
-    foreach ($ext in TryCmd {Get-VMSwitch -Name $name | Get-VMSwitchExtension}) {
-        if (($ext.Name -like "Microsoft Azure VFP Switch Extension") -and ($ext.Enabled -like "True")) {
-            VfpExtensionWorker -VMSwitchName $name -OutDir $out
-        }
-    }
-
 } # VfpExtensionDetail()
 
 function VMSwitchDetail {
@@ -1683,14 +1605,14 @@ function VMSwitchDetail {
     )
 
     # FIXME!!!
-    ##See this command to get VFs on vSwitch
-    #Get-NetAdapterSriovVf -SwitchId 2
+    # See this command to get VFs on vSwitch
+    # Get-NetAdapterSriovVf -SwitchId 2
 
     foreach ($vSwitch in TryCmd {Get-VMSwitch}) {
         $name = $vSwitch.Name
         $type = $vSwitch.SwitchType
 
-        $dir  = (Join-Path -Path $OutDir -ChildPath ("VMSwitch.$type.$name"))
+        $dir  = (Join-Path -Path $OutDir -ChildPath "VMSwitch.$type.$name")
         New-Item -ItemType directory -Path $dir | Out-Null
 
         Write-Host "Processing: $name"

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -1447,7 +1447,7 @@ function HNSDetail {
     )
 
     try {
-        Get-Service "hns" -ErrorAction Stop
+        $null = Get-Service "hns" -ErrorAction Stop
     } catch {
         Write-Host "HNSDetail: hns service not found, skipping."
         return
@@ -1476,7 +1476,7 @@ function HNSDetail {
     try {
         if ($hnsRunning) {
             # Force stop to avoid command line prompt
-            net stop hns /y
+            $null = net stop hns /y
         }
 
         $file = "HNSData.txt"
@@ -1484,7 +1484,7 @@ function HNSDetail {
         ExecCommands -OutDir $dir -File $file -Commands $cmds
     } finally {
         if ($hnsRunning) {
-            net start hns
+            $null = net start hns
         }
     }
 

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -1682,7 +1682,7 @@ function Counters {
     # Get paths for counters of interest
     # Be careful what you add to this, Get-Counter runtime scales
     # exponetially with respect to the number of counter instances.
-    $listSet = @("Hyper-V*", "ICMP*", "*Intel*", "IP*", "*Mellanox*", "Network*", "Physical Network", "RDMA*", "SMB*", "TCP*", "UDP*","VFP*", "WFP*", "*WinNAT*")
+    $listSet = @("Hyper-V*", "ICMP*", "*Intel*", "IP*", "*Mellanox*", "Network*", "Physical Network*", "RDMA*", "SMB*", "TCP*", "UDP*","VFP*", "WFP*", "*WinNAT*")
     $counterPaths = (Get-Counter -ListSet $listSet -ErrorAction SilentlyContinue | Sort-Object -Unique -Property "CounterSetName").PathsWithInstances
 
     # Filter counter instances

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -29,7 +29,7 @@
     which can be accessed by using "$CustomModule" as a placeholder. For example, {Copy-Item .\MyFile.txt $CustomModule}
     copies "MyFile.txt" to "CustomModule\MyFile.txt".
 .PARAMETER MaxThreads
-    Maximum number of simultaneous background tasks. TODO
+    Maximum number of simultaneous background tasks, from 1 to 10. Defaults to 4.
 .PARAMETER SkipAdminCheck
     If this switch is present, then the check for administrator privileges will be skipped.
     Note that less data may be collected and the results may be of limited use.
@@ -60,8 +60,8 @@ Param(
     [ScriptBlock[]] $ExtraCommands = @(),
 
     [parameter(Mandatory=$false)]
-    [ValidateRange(0, [Int]::MaxValue)]
-    [Int] $MaxThreads = 0,
+    [ValidateRange(1, 10)]
+    [Int] $MaxThreads = 4,
 
     [parameter(Mandatory=$false)]
     [Switch] $SkipAdminCheck = $false
@@ -170,16 +170,16 @@ $ExecFunctions = {
 
         if ($Trusted) {
             # Skip command validation
-            Write-Host -ForegroundColor Cyan "$Command"
+            Write-Host "$Command"
             ExecCommandPrivate -Command $Command -Output $Output
         } else {
             $result, $failure = TestCommand -Command $Command
 
             if ($result -eq [CommandStatus]::Succeeded) {
-                Write-Host -ForegroundColor Green "$Command"
+                Write-Host "$Command"
                 ExecCommandPrivate -Command $Command -Output $Output
             } else {
-                Write-Warning "[Command $result] $Command"
+                Write-Host "[Command $result] $Command"
 
                 Write-Output "[Command $result]" | Out-File -Encoding ascii -Append $Output
                 Write-Output "$Command" | Out-File -Encoding ascii -Append $Output
@@ -189,40 +189,50 @@ $ExecFunctions = {
         }
     } # ExecCommand()
 
-    function TryCmd {
+    function ExecCommands {
         [CmdletBinding()]
         Param(
-            [parameter(Mandatory=$true)] [ScriptBlock] $ScriptBlock
+            [parameter(Mandatory=$false)] [Switch] $Trusted,
+            [parameter(Mandatory=$true)] [String] $File,
+            [parameter(Mandatory=$true)] [String] $OutDir,
+            [parameter(Mandatory=$true)] [String[]] $Commands
         )
-
-        try {
-            $out = &$ScriptBlock
-        } catch {
-            $out = $null
+    
+        $out = (Join-Path -Path $OutDir -ChildPath $File)
+        foreach ($cmd in $Commands) {
+            ExecCommand -Trusted:$Trusted -Command ($cmd) -Output $out
         }
-
-        # Returning $null will cause foreach to iterate once
-        # unless TryCmd call is in parentheses.
-        if ($out -eq $null) {
-            $out = @() 
-        }
-
-        return $out
-    }
+    } # ExecCommands()
 } # $ExecFunctions
 
 . $ExecFunctions # import into script context
 
-function Initialize-GlobalThreadPool {
+function TryCmd {
     [CmdletBinding()]
     Param(
-        [Int] $MaxThreads = 0
+        [parameter(Mandatory=$true)] [ScriptBlock] $ScriptBlock
     )
 
-    if ($MaxThreads -eq 0)
-    {
-        $MaxThreads = 4 # TODO base on hardware
+    try {
+        $out = &$ScriptBlock
+    } catch {
+        $out = $null
     }
+
+    # Returning $null will cause foreach to iterate once
+    # unless TryCmd call is in parentheses.
+    if ($out -eq $null) {
+        $out = @() 
+    }
+
+    return $out
+} # TryCmd()
+
+function Open-GlobalThreadPool {
+    [CmdletBinding()]
+    Param(
+        [parameter(Mandatory=$true)] [Int] $MaxThreads
+    )
 
     if ($Global:ThreadPool -eq $null)
     {
@@ -237,6 +247,7 @@ function Close-GlobalThreadPool {
 
     if ($Global:ThreadPool -ne $null)
     {
+        Write-Host "Cleanup background threads..."
         $Global:ThreadPool.Close()
         $Global:ThreadPool.Dispose()
         $Global:ThreadPool = $null
@@ -256,41 +267,48 @@ function Start-Thread {
     $ps.RunspacePool = $Global:ThreadPool
     $null = $ps.AddScript("Set-Location ""$(Resolve-Path $StartPath)""")
     $null = $ps.AddScript($ExecFunctions) # import into thread context
-    $null = $ps.AddScript($ScriptBlock).AddParameters($Params)
+    $null = $ps.AddScript($ScriptBlock, $true).AddParameters($Params)
 
     $async = $ps.BeginInvoke()
 
     return @{Name=$ScriptBlock.Ast.Name; AsyncResult=$async; PowerShell=$ps}
 } # Start-Thread()
 
-function Remove-Thread {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [Hashtable] $Thread
-    )
-    Write-Host "Stopping thread $($Thread.Name)..."
-    $Thread.PowerShell.Stop()
-    $Thread.PowerShell.Dispose()
-} # Remove-Thread
-
-function StreamThread {
+function Show-Thread {
     [CmdletBinding()]
     Param(
         [parameter(Mandatory=$true)] [Hashtable] $Thread
     )
 
-    Write-Host "`nOn thread: $($Thread.Name)"
-    Write-Host "----------------------------------------------"
-
-    do {
-        Start-Sleep -Milliseconds 50
-        # TODO output errors/other streams
+    while ($true) {
+        $Thread.Powershell.Streams.Error | Out-Host
+        $Thread.PowerShell.Streams.Warning | Out-Host
         $Thread.PowerShell.Streams.Information | Out-Host
-        $Thread.PowerShell.Streams.Information.Clear()
-    } until ($Thread.AsyncResult.IsCompleted)
+
+        $Thread.PowerShell.Streams.ClearStreams()
+
+        if ($Thread.AsyncResult.IsCompleted)
+        {
+            break
+        }
+
+        Start-Sleep -Milliseconds 16.667
+    }
 
     $Thread.PowerShell.EndInvoke($Thread.AsyncResult)
-} # StreamThread()
+} # Show-Thread()
+
+function ExecCommandsAsync {
+    [CmdletBinding()]
+    Param(
+        [parameter(Mandatory=$false)] [Switch] $Trusted,
+        [parameter(Mandatory=$true)] [String] $File,
+        [parameter(Mandatory=$true)] [String] $OutDir,
+        [parameter(Mandatory=$true)] [String[]] $Commands
+    )
+
+    return Start-Thread -ScriptBlock ${function:ExecCommands} -Params $PSBoundParameters
+} # ExecCommandsAsync()
 
 #
 # Data Collection Functions
@@ -308,44 +326,32 @@ function NetIpNic{
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "Get-NetIpAddress.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetIpAddress -InterfaceAlias ""$name"" | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetIpAddress -InterfaceAlias ""$name"" | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetIpAddress -InterfaceAlias ""$name"" | Format-List",
                         "Get-NetIpAddress -InterfaceAlias ""$name"" | Format-List -Property *",
                         "Get-NetIpAddress | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetIPInterface.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetIPInterface -InterfaceAlias ""$name"" | Out-String -Width $columns",
                         "Get-NetIPInterface -InterfaceAlias ""$name"" | Format-Table -AutoSize",
                         "Get-NetIPInterface -InterfaceAlias ""$name"" | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetIPInterface | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetNeighbor.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetNeighbor -InterfaceAlias ""$name"" | Out-String -Width $columns",
-                        "Get-NetNeighbor -InterfaceAlias ""$name"" | Format-Table -AutoSiz | Out-String -Width $columns",
+                        "Get-NetNeighbor -InterfaceAlias ""$name"" | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetNeighbor -InterfaceAlias ""$name"" | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetNeighbor | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetRoute.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetRoute -InterfaceAlias ""$name"" | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetRoute -InterfaceAlias ""$name"" | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetRoute | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # NetIpNic()
 
 function NetIp {
@@ -354,134 +360,95 @@ function NetIp {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $dir    = (Join-Path -Path $OutDir -ChildPath "NetIp")
+    $dir = (Join-Path -Path $OutDir -ChildPath "NetIp")
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "Get-NetIpAddress.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetIpAddress | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetIpAddress | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetIpAddress | Format-List",
                         "Get-NetIpAddress | Format-List -Property *",
                         "Get-NetIpAddress | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetIPInterface.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetIPInterface | Out-String -Width $columns",
                         "Get-NetIPInterface | Format-Table -AutoSize  | Out-String -Width $columns",
                         "Get-NetIPInterface | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetIPInterface | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetNeighbor.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetNeighbor | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetNeighbor | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetNeighbor | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetIPv4Protocol.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetIPv4Protocol | Out-String -Width $columns",
                         "Get-NetIPv4Protocol | Format-List  -Property *",
                         "Get-NetIPv4Protocol | Format-Table -Property * -AutoSize",
                         "Get-NetIPv4Protocol | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetIPv4Protocol | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetIPv6Protocol.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetIPv6Protocol | Out-String -Width $columns",
                         "Get-NetIPv6Protocol | Format-List  -Property *",
                         "Get-NetIPv6Protocol | Format-Table -Property * -AutoSize",
                         "Get-NetIPv6Protocol | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetIPv6Protocol | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetOffloadGlobalSetting.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetOffloadGlobalSetting | Out-String -Width $columns",
                         "Get-NetOffloadGlobalSetting | Format-List  -Property *",
                         "Get-NetOffloadGlobalSetting | Format-Table -AutoSize",
                         "Get-NetOffloadGlobalSetting | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetOffloadGlobalSetting | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetPrefixPolicy.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetPrefixPolicy | Format-Table -AutoSize",
                         "Get-NetPrefixPolicy | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetPrefixPolicy | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetRoute.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetRoute | Format-Table -AutoSize",
                         "Get-NetRoute | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetRoute | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetTCPConnection.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetTCPConnection | Format-Table -AutoSize",
                         "Get-NetTCPConnection | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetTCPConnection | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Trusted -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -Trusted -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetTcpSetting.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetTcpSetting  | Format-Table -AutoSize",
                         "Get-NetTcpSetting  | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetTcpSetting  | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Trusted -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -Trusted -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetTransportFilter.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetTransportFilter  | Format-Table -AutoSize",
                         "Get-NetTransportFilter  | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetTransportFilter  | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetUDPEndpoint.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetUDPEndpoint  | Format-Table -AutoSize",
                         "Get-NetUDPEndpoint  | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetUDPEndpoint  | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetUDPSetting.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetUDPSetting  | Format-Table -AutoSize",
                         "Get-NetUDPSetting  | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetUDPSetting  | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # NetIp()
 
 function NetNat {
@@ -494,59 +461,44 @@ function NetNat {
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "Get-NetNat.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetNat | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetNat | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetNat | Format-List",
                         "Get-NetNat | Format-List -Property *",
                         "Get-NetNat | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetNatExternalAddress.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetNatExternalAddress | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetNatExternalAddress | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetNatExternalAddress | Format-List",
                         "Get-NetNatExternalAddress | Format-List -Property *",
                         "Get-NetNatExternalAddress | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetNatGlobal.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetNatGlobal | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetNatGlobal | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetNatGlobal | Format-List",
                         "Get-NetNatGlobal | Format-List -Property *",
                         "Get-NetNatGlobal | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetNatSession.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetNatSession | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetNatSession | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetNatSession | Format-List",
                         "Get-NetNatSession | Format-List -Property *",
                         "Get-NetNatSession | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetNatStaticMapping.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetNatStaticMapping | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetNatStaticMapping | Format-Table -Property * -AutoSize | Out-String -Width $columns",
                         "Get-NetNatStaticMapping | Format-List",
                         "Get-NetNatStaticMapping | Format-List -Property *",
                         "Get-NetNatStaticMapping | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
 } # NetNat()
 
@@ -561,186 +513,126 @@ function NetAdapterWorker {
     $dir  = $OutDir
 
     $file = "Get-NetAdapter.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapter -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapter -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapter | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterAdvancedProperty.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties | Sort-Object RegistryKeyword | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties -IncludeHidden | Sort-Object RegistryKeyword | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterAdvancedProperty -Name ""$name"" -AllProperties -IncludeHidden | Format-Table  -Property * | Out-String -Width $columns",
                         "Get-NetAdapterAdvancedProperty | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterBinding.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterBinding -Name ""$name"" -AllBindings -IncludeHidden | Sort-Object ComponentID | Out-String -Width $columns",
                         "Get-NetAdapterBinding -Name ""$name"" -AllBindings -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterBinding | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterChecksumOffload.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterChecksumOffload -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterChecksumOffload -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterChecksumOffload | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterLso.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterLso -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterLso -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterLso | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterRss.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterRss -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterRss -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterRss | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterStatistics.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterStatistics -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterStatistics -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterStatistics | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterEncapsulatedPacketTaskOffload.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterEncapsulatedPacketTaskOffload -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterEncapsulatedPacketTaskOffload -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterEncapsulatedPacketTaskOffload | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterHardwareInfo.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterHardwareInfo -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterHardwareInfo -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterHardwareInfo | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterIPsecOffload.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterIPsecOffload -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterIPsecOffload -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterIPsecOffload | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterPowerManagement.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterPowerManagement -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterPowerManagement -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterPowerManagement | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterQos.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterQos -Name ""$name"" -IncludeHidden -ErrorAction SilentlyContinue | Out-String -Width $columns",
                         "Get-NetAdapterQos -Name ""$name"" -IncludeHidden -ErrorAction SilentlyContinue | Format-List  -Property *",
                         "Get-NetAdapterQos | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterRdma.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterRdma -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterRdma -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterRdma | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterPacketDirect.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterPacketDirect -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterPacketDirect -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterPacketDirect | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterRsc.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterRsc -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterRsc -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterRsc | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterSriov.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterSriov -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterSriov -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterSriov | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterSriovVf.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterSriovVf -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterSriovVf -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterSriovVf | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterVmq.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterVmq -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterVmq -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterVmq | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterVmqQueue.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterVmqQueue -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterVmqQueue -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterVmqQueue | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterVPort.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetAdapterVPort -Name ""$name"" -IncludeHidden | Out-String -Width $columns",
                         "Get-NetAdapterVPort -Name ""$name"" -IncludeHidden | Format-List  -Property *",
                         "Get-NetAdapterVPort | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # NetAdapterWorker()
 
 function NetAdapterWorkerPrepare {
@@ -750,23 +642,17 @@ function NetAdapterWorkerPrepare {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    # Normalize Variables
-    $out  = $OutDir
     $desc = $NicDesc
 
     # Create dir for each NIC
     $nic     = Get-NetAdapter -InterfaceDescription $desc
     $idx     = $nic.IfIndex
     $name    = $nic.Name
-    $desc    = $NicDesc
-    $nictype = "pNic"
-    $title   = "$nictype.$idx.$name.$desc"
-    $dir     = (Join-Path -Path $out -ChildPath "$title")
+    $title   = "pNic.$idx.$name.$desc"
+    $dir     = (Join-Path -Path $OutDir -ChildPath "$title")
     New-Item -ItemType directory -Path $dir | Out-Null
 
-    Write-Host ""
     Write-Host "Processing: $title"
-    Write-Host "----------------------------------------------"
     NetIpNic         -NicName $name -OutDir $dir
     NetAdapterWorker -NicName $name -OutDir $dir
     NicVendor        -NicName $name -OutDir $dir
@@ -779,39 +665,28 @@ function LbfoWorker {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    # Normalize Variable
     $name = $LbfoName
-    $dir  = (Join-Path -Path $OutDir -ChildPath ("LBFO.$name"))
+    $dir  = (Join-Path -Path $OutDir -ChildPath "LBFO.$name")
     New-Item -ItemType directory -Path $dir | Out-Null
 
     Write-Host "Processing: $name"
-    Write-Host "----------------------------------------------"
     $file = "Get-NetLbfoTeam.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetLbfoTeam -Name ""$name""",
                         "Get-NetLbfoTeam -Name ""$name"" | Format-List  -Property *",
                         "Get-NetLbfoTeam | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetLbfoTeamNic.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetLbfoTeamNic -Team ""$name""",
                         "Get-NetLbfoTeamNic -Team ""$name"" | Format-List  -Property *",
                         "Get-NetLbfoTeamNic | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetLbfoTeamMember.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetLbfoTeamMember -Team ""$name""",
                         "Get-NetLbfoTeamMember -Team ""$name"" | Format-List  -Property *",
                         "Get-NetLbfoTeamMember | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     # Report the TNIC(S)
     foreach ($tnic in TryCmd {Get-NetLbfoTeamNic -Team $name}) {
@@ -830,25 +705,27 @@ function LbfoDetail {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    # Normalize variables
-    $out = $OutDir
+    $dir = $OutDir
+
+    # Cache output
+    $externalVMSwitches = TryCmd {Get-VMSwitch | where {$_.SwitchType -eq "External"}}
 
     foreach ($lbfo in TryCmd {Get-NetLbfoTeam}) {
-        $name = $lbfo.Name
-
         # Skip all vSwitch Protocol NICs since the LBFO and member reporting will occur as part of
         # vSwitch reporting.
         $match = $false
 
-        foreach ($vms in TryCmd {Get-VMSwitch | where {$_.SwitchType -ne "Internal"}}) {
-            if ($vms.NetAdapterInterfaceDescriptions -contains (Get-NetAdapter -Name $name).InterfaceDescription) {
+        $netAdapter = Get-NetAdapter -Name $lbfo.Name
+
+        foreach ($vmSwitch in $externalVMSwitches) {
+            if ($vmSwitch.NetAdapterInterfaceDescriptions -contains $netAdapter.InterfaceDescription) {
                 $match = $true
                 break
             }
         }
 
         if (-not $match) {
-            LbfoWorker -LbfoName $name -OutDir $out
+            LbfoWorker -LbfoName $lbfo.Name -OutDir $dir
         }
     }
 } # LbfoDetail()
@@ -860,16 +737,15 @@ function ProtocolNicDetail {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    # Normalize Variables
-    $out = $OutDir
+    $dir = $OutDir
 
     # Distinguish between LBFO from standard PTNICs and create the hierarchies accordingly
     foreach ($desc in TryCmd {(Get-VMSwitch -Name "$VMSwitchName").NetAdapterInterfaceDescriptions}) {
         $nic = Get-NetAdapter -InterfaceDescription $desc
         if ($nic.DriverFileName -like "NdisImPlatform.sys") {
-            LbfoWorker -LbfoName $nic.Name -OutDir $out
+            LbfoWorker -LbfoName $nic.Name -OutDir $dir
         } else {
-            NetAdapterWorkerPrepare -NicDesc $desc -OutDir $out
+            NetAdapterWorkerPrepare -NicDesc $desc -OutDir $dir
         }
     }
 } # ProtocolNicDetail()
@@ -880,8 +756,11 @@ function NativeNicDetail {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    # Normalize Variables
-    $out = $OutDir
+    $dir = $OutDir
+
+    # Cache output
+    $externalVMSwitches = TryCmd {Get-VMSwitch | where {$_.SwitchType -eq "External"}}
+    $lbfoNics = TryCmd {Get-NetLbfoTeamMember}
 
     foreach ($nic in Get-NetAdapter) {
         $native = $true
@@ -897,15 +776,15 @@ function NativeNicDetail {
         }
 
         # Skip all vSwitch Protocol NICs
-        foreach ($vms in TryCmd {Get-VMSwitch | where {$_.SwitchType -ne "Internal"}}) {
-            if ($vms.NetAdapterInterfaceDescriptions -contains $nic.InterfaceDescription) {
+        foreach ($vmSwitch in $externalVMSwitches) {
+            if ($vmSwitch.NetAdapterInterfaceDescriptions -contains $nic.InterfaceDescription) {
                 $native = $false
                 break
             }
         }
 
         # Skip LBFO Team Member Adapters
-        foreach ($lbfonic in TryCmd {Get-NetLbfoTeamMember}) {
+        foreach ($lbfonic in $lbfoNics) {
             if ($nic.InterfaceDescription -eq $lbfonic.InterfaceDescription) {
                 $native = $false
                 break
@@ -913,7 +792,7 @@ function NativeNicDetail {
         }
 
         if ($native) {
-            NetAdapterWorkerPrepare -NicDesc $nic.InterfaceDescription -OutDir $out
+            NetAdapterWorkerPrepare -NicDesc $nic.InterfaceDescription -OutDir $dir
         }
     }
 } # NativeNicDetail()
@@ -930,29 +809,20 @@ function ChelsioDetail {
 
     # Collect Chelsio related event logs and miscellaneous details
     $file = "ChelsioDetail-Eventlog-BusDevice.txt"
-    $out = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-EventLog -LogName System -Source ""*chvbd*"" -ErrorAction SilentlyContinue | Format-List",
                         "Get-EventLog -LogName System -Source ""*cht4vbd*"" -ErrorAction SilentlyContinue | Format-List"
-    foreach ($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "ChelsioDetail-Eventlog-NetDevice.txt"
-    $out = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-EventLog -LogName System -Source ""*chndis*"" -ErrorAction SilentlyContinue | Format-List",
                         "Get-EventLog -LogName System -Source ""*chnet*"" -ErrorAction SilentlyContinue | Format-List",
                         "Get-EventLog -LogName System -Source ""*cht4ndis*"" -ErrorAction SilentlyContinue | Format-List"
-    foreach ($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "ChelsioDetail-Misc.txt"
-    $out = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "verifier /query",
                         "Get-PnpDevice -FriendlyName ""*Chelsio*Enumerator*"" | Get-PnpDeviceProperty -KeyName DEVPKEY_Device_DriverVersion | Format-Table -Autosize"
-    foreach ($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     # Basic sanity check. Most of Chelsio related logs are collected using cxgbtool.exe.
     # So if cxgbtool.exe is not there in System32 forlder, then exit from the function.
@@ -992,17 +862,13 @@ function ChelsioDetail {
         $file = "ChelsioDetail-Cudbg.txt"
         $CollectFile = "Cudbg-Collect.dmp"
         $ReadFlashFile = "Cudbg-Readflash.dmp"
-        $out  = (Join-Path -Path $dirBus -ChildPath $file)
         $OutCollect = (Join-Path -Path $dirBus -ChildPath $CollectFile)
         $OutReadFlash = (Join-Path -Path $dirBus -ChildPath $ReadFlashFile)
         [String []] $cmds = "cxgbtool.exe $ifNameVbd cudbg collect all ""$OutCollect""",
                             "cxgbtool.exe $ifNameVbd cudbg readflash ""$OutReadFlash"""
-        foreach ($cmd in $cmds) {
-            ExecCommand -Trusted -Command $cmd -Output $out
-        }
+        ExecCommandsAsync -Trusted -OutDir $dirBus -File $file -Commands $cmds
 
         $file = "ChelsioDetail-Firmware-BusDevice$i.txt"
-        $out  = (Join-Path -Path $dirBus -ChildPath $file)
         [String []] $cmds = "cxgbtool.exe $ifNameVbd firmware mbox 1",
                             "cxgbtool.exe $ifNameVbd firmware mbox 2",
                             "cxgbtool.exe $ifNameVbd firmware mbox 3",
@@ -1010,19 +876,14 @@ function ChelsioDetail {
                             "cxgbtool.exe $ifNameVbd firmware mbox 5",
                             "cxgbtool.exe $ifNameVbd firmware mbox 6",
                             "cxgbtool.exe $ifNameVbd firmware mbox 7"
-        foreach ($cmd in $cmds) {
-            ExecCommand -Command $cmd -Output $out
-        }
+        ExecCommandsAsync -OutDir $dirBus -File $file -Commands $cmds
 
         $file = "ChelsioDetail-Hardware-BusDevice$i.txt"
         $flashFile = "Hardware-BusDevice$i-flash.dmp"
-        $out = (Join-Path -Path $dirBus -ChildPath $file)
         $OutFlash = (Join-Path -Path $dirBus -ChildPath $flashFile)
         [String []] $cmds = "cxgbtool.exe $ifNameVbd hardware sgedbg",
                             "cxgbtool.exe $ifNameVbd hardware flash ""$OutFlash"""
-        foreach ($cmd in $cmds) {
-            ExecCommand -Command $cmd -Output $out
-        }
+        ExecCommandsAsync -OutDir $dirBus -File $file -Commands $cmds
     } # $Global:ChelsioOncePerASIC
 
     $dirNetName = "NetDev_$ifIndex"
@@ -1045,7 +906,6 @@ function ChelsioDetail {
     }
 
     $file = "ChelsioDetail-Debug.txt"
-    $out  = (Join-Path -Path $dirNet -ChildPath $file)
     [String []] $cmds = "cxgbtool.exe $ifNameNic debug filter",
                         "cxgbtool.exe $ifNameNic debug qsets",
                         "cxgbtool.exe $ifNameNic debug qstats txeth rxeth txvirt rxvirt txrdma rxrdma txnvgre rxnvgre",
@@ -1056,20 +916,15 @@ function ChelsioDetail {
                         "cxgbtool.exe $ifNameNic debug rdma_stats",
                         "cxgbtool.exe $ifNameNic debug stags",
                         "cxgbtool.exe $ifNameNic debug l2t"
-    foreach ($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommandsAsync -OutDir $dirNet -File $file -Commands $cmds
 
     $file = "ChelsioDetail-Hardware.txt"
-    $out  = (Join-Path -Path $dirNet -ChildPath $file)
     [String []] $cmds = "cxgbtool.exe $ifNameNic hardware tid_info",
                         "cxgbtool.exe $ifNameNic hardware fec",
                         "cxgbtool.exe $ifNameNic hardware link_cfg",
                         "cxgbtool.exe $ifNameNic hardware pktfilter",
                         "cxgbtool.exe $ifNameNic hardware sensor"
-    foreach ($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommandsAsync -OutDir $dirNet -File $file -Commands $cmds
 } # ChelsioDetail()
 
 # ========================================================================
@@ -1089,14 +944,11 @@ function MyVendorDetail {
     # Feel free to copy it or wrap it in other control structures
     # See other functions in this file for examples
     $file = "$NicName.MyVendor.txt"
-    $out = Join-Path $dir $file
     [String []] $cmds = "Command 1",
                         "Command 2",
                         "Command 3",
                         "etc."
-    foreach ($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # MyVendorDetail()
 
 function NicVendor {
@@ -1136,81 +988,56 @@ function HostVNicWorker {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    # Normalize Names
     $name = $HostVNicName
     $dir  = $OutDir
 
     $file = "Get-VMNetworkAdapter.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapter -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapter -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *",
                         "Get-VMNetworkAdapter -ManagementOS| Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterAcl.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapterAcl -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapterAcl -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *",
                         "Get-VMNetworkAdapterAcl -ManagementOS | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterExtendedAcl.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapterExtendedAcl -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapterExtendedAcl -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *",
                         "Get-VMNetworkAdapterExtendedAcl -ManagementOS | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterFailoverConfiguration.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapterFailoverConfiguration -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapterFailoverConfiguration -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *",
                         "Get-VMNetworkAdapterFailoverConfiguration -ManagementOS | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterIsolation.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapterIsolation -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapterIsolation -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *",
                         "Get-VMNetworkAdapterIsolation -ManagementOS | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterRoutingDomainMapping.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapterRoutingDomainMapping -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapterRoutingDomainMapping -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List -Property *",
                         "Get-VMNetworkAdapterRoutingDomainMapping -ManagementOS | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterTeamMapping.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapterTeamMapping -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapterTeamMapping -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *",
                         "Get-VMNetworkAdapterTeamMapping -ManagementOS | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterVlan.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapterVlan -ManagementOS -VMNetworkAdapterName ""$name"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapterVlan -ManagementOS -VMNetworkAdapterName ""$name"" | Format-List  -Property *",
                         "Get-VMNetworkAdapterVlan -ManagementOS | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # HostVNicWorker()
 
 function HostVNicDetail {
@@ -1219,6 +1046,9 @@ function HostVNicDetail {
         [parameter(Mandatory=$true)] [String] $VMSwitchName,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
+
+    # Cache output
+    $allNetAdapters = Get-NetAdapter -IncludeHidden
 
     foreach ($nic in TryCmd {Get-VMNetworkAdapter -ManagementOS -SwitchName $VMSwitchName}) {
         <#
@@ -1234,7 +1064,7 @@ function HostVNicDetail {
             we can execute VMNetworkAdapter and NetAdapter information for this hNIC
         #>
         $idx = 0
-        foreach($pnic in (Get-NetAdapter -IncludeHidden)) {
+        foreach($pnic in $allNetAdapters) {
             if ($pnic.DeviceID -eq $nic.DeviceId) {
                 $pnicname = $pnic.Name
                 $idx      = $pnic.IfIndex
@@ -1243,14 +1073,12 @@ function HostVNicDetail {
 
         # Create dir for each NIC
         $name    = $nic.Name
-        $nictype = "hNic"
-        $title   = "$nictype.$idx.$name"
+        $title   = "hNic.$idx.$name"
         $dir     = (Join-Path -Path $OutDir -ChildPath "$title")
         New-Item -ItemType directory -Path $dir | Out-Null
 
         Write-Host "Processing: $title"
-        Write-Host "----------------------------------------------"
-        NetIpNic         -NicName      $pnicname -OutDir $dir
+        $threads = NetIpNic         -NicName      $pnicname -OutDir $dir
         HostVNicWorker   -HostVNicName $name     -OutDir $dir
         NetAdapterWorker -NicName      $pnicname -OutDir $dir
     }
@@ -1260,175 +1088,121 @@ function VMNetworkAdapterDetail {
     [CmdletBinding()]
     Param(
         [parameter(Mandatory=$true)] [String] $VMName,
-        [parameter(Mandatory=$true)] [String] $VmNicName,
+        [parameter(Mandatory=$true)] [String] $VMNicName,
         [parameter(Mandatory=$true)] [String] $VMNicMac,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
     $name = $VMNicName
-    $title = "VMNic.$VmNicName.$VMNicMac"
+    $title = "VMNic.$VMNicName.$VMNicMac"
     $dir  = (Join-Path -Path $OutDir -ChildPath $title)
     New-Item -ItemType directory -Path $dir | Out-Null
 
     Write-Host "Processing: $title"
-    Write-Host "--------------------------------------"
     $file = "Get-VMNetworkAdapter.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapter -Name ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapter -Name ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
                         "Get-VMNetworkAdapter * | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterAcl.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapterAcl -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapterAcl -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
                         "Get-VMNetworkAdapterAcl | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterExtendedAcl.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapterExtendedAcl -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapterExtendedAcl -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
                         "Get-VMNetworkAdapterExtendedAcl | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterFailoverConfiguration.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapterFailoverConfiguration -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapterFailoverConfiguration -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
                         "Get-VMNetworkAdapterFailoverConfiguration -VMName * | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterIsolation.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapterIsolation -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapterIsolation -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
                         "Get-VMNetworkAdapterIsolation | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterRoutingDomainMapping.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapterRoutingDomainMapping -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapterRoutingDomainMapping -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
                         "Get-VMNetworkAdapterRoutingDomainMapping | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterTeamMapping.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapterTeamMapping -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapterTeamMapping -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
                         "Get-VMNetworkAdapterTeamMapping -VMName * | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapterVlan.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMNetworkAdapterVlan -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMNetworkAdapterVlan -VMNetworkAdapterName ""$name"" -VMName ""$VMName"" | Format-List  -Property *",
                         "Get-VMNetworkAdapterVlan | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # VMNetworkAdapterDetail()
 
-function VmWorker {
+function VMWorker {
     [CmdletBinding()]
     Param(
         [parameter(Mandatory=$true)] [String] $VMName,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    # Normalize Names
     $dir  = $OutDir
 
     $file = "Get-VM.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VM -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VM -VMName ""$VMName"" | Format-List  -Property *",
                         "Get-VM | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMBios.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMBios -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMBios -VMName ""$VMName"" | Format-List  -Property *"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMFirmware.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMFirmware -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMFirmware -VMName ""$VMName"" | Format-List  -Property *"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMProcessor.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMProcessor -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMProcessor -VMName ""$VMName"" | Format-List  -Property *"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMMemory.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMMemory -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMMemory -VMName ""$VMName"" | Format-List  -Property *"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMVideo.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMVideo -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMVideo -VMName ""$VMName"" | Format-List  -Property *"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMHardDiskDrive.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMHardDiskDrive -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMHardDiskDrive -VMName ""$VMName"" | Format-List  -Property *"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMComPort.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMComPort -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMComPort -VMName ""$VMName"" | Format-List  -Property *"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSecurity.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMSecurity -VMName ""$VMName"" | Out-String -Width $columns",
                         "Get-VMSecurity -VMName ""$VMName"" | Format-List  -Property *"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
-
-} # VmWorker()
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
+} # VMWorker()
 
 function VMNetworkAdapterPerVM {
     [CmdletBinding()]
@@ -1442,7 +1216,6 @@ function VMNetworkAdapterPerVM {
         $vmid   = $vm.VMId
 
         Write-Host "Processing: VM.$vmname.$vmid"
-        Write-Host "--------------------------------------"
         foreach ($nic in TryCmd {Get-VMNetworkAdapter -VMName $vmname}) {
             if ($nic.SwitchName -eq $VMSwitchName) {
                 $vmquery = 0
@@ -1453,9 +1226,9 @@ function VMNetworkAdapterPerVM {
                 }
 
                 if ($vmquery) {
-                    VmWorker -VMName $vmname -OutDir $dir
+                    VMWorker -VMName $vmname -OutDir $dir
                 }
-                VmNetworkAdapterDetail -VMName $vmname -VmNicName $nic.Name -VmNicMac $nic.MacAddress -OutDir $dir
+                VmNetworkAdapterDetail -VMName $vmname -VMNicName $nic.Name -VMNicMac $nic.MacAddress -OutDir $dir
             }
         }
     }
@@ -1468,86 +1241,58 @@ function VMSwitchWorker {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    # Normalize Names
     $name = $VMSwitchName
     $dir  = $OutDir
 
     $file = "Get-VMSwitch.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMSwitch -Name ""$name""",
                         "Get-VMSwitch -Name ""$name"" | Format-List  -Property *",
                         "Get-VMSwitch -Name ""$name"" | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchExtension.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMSwitch -Name ""$name"" | Get-VMSwitchExtension | Format-List  -Property *",
                         "Get-VMSwitch -Name ""$name"" | Get-VMSwitchExtension | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchExtensionSwitchData.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMSwitchExtensionSwitchData -SwitchName ""$name"" | Format-List  -Property *",
                         "Get-VMSwitchExtensionSwitchData -SwitchName ""$name"" | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchExtensionSwitchFeature.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMSwitchExtensionSwitchFeature -SwitchName ""$name"" | Format-List -Property *"
                         #"Get-VMSwitchExtensionSwitchFeature -SwitchName ""$name"" | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchTeam.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMSwitchTeam -SwitchName ""$name"" | Format-List -Property *",
                         "Get-VMSwitchTeam -SwitchName ""$name"" | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSystemSwitchExtension.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMSystemSwitchExtension | Format-List -Property *",
                         "Get-VMSystemSwitchExtension | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSwitchExtensionPortFeature.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMSwitchExtensionPortFeature * | Format-List -Property *",
                         "Get-VMSwitchExtensionPortFeature * | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMSystemSwitchExtensionSwitchFeature.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMSystemSwitchExtensionSwitchFeature",
                         "Get-VMSystemSwitchExtensionSwitchFeature | Format-List  -Property *",
                         "Get-VMSystemSwitchExtensionSwitchFeature | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     <#
     #Get-VMSwitchExtensionPortData -ComputerName $env:computername *
     # Execute command list
     $file = "Get-VMSwitchExtensionPortData.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-VMSwitchExtensionPortData -SwitchName ""$name"" | Format-List  -Property *",
                         "Get-VMSwitchExtensionPortData -SwitchName ""$name"" | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
     #>
 } # VMSwitchWorker()
 
@@ -1569,32 +1314,26 @@ function VfpExtensionDetail {
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "VfpCtrl.help.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "vfpctrl.exe /h"
-    foreach ($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $switches = Get-WmiObject -Namespace "root\virtualization\v2" -Class "Msvm_VirtualEthernetSwitch"
-    foreach ($vSwitch in $switches) {
-        if ($vSwitch.ElementName -eq $name) {
-            $currswitch = $vSwitch
+    foreach ($vmSwitch in $switches) {
+        if ($vmSwitch.ElementName -eq $name) {
+            $currswitch = $vmSwitch
             break
         }
     }
 
     $ports = $currswitch.GetRelated("Msvm_EthernetSwitchPort", "Msvm_SystemDevice", $null, $null, $null, $null, $false, $null)
     foreach ($port in $ports) {
-        $portGuid = $port.Name
         $file     = "VfpCtrl.PortGuid.$portGuid.txt"
-        $out      = (Join-Path -Path $dir -ChildPath $file)
+        $portGuid = $port.Name
         [String []] $cmds = "vfpctrl.exe /list-space /port $portGuid",
                             "vfpctrl.exe /list-mapping /port $portGuid",
                             "vfpctrl.exe /list-rule /port $portGuid",
                             "vfpctrl.exe /port $portGuid /get-port-state"
-        foreach ($cmd in $cmds) {
-            ExecCommand -Command ($cmd) -Output $out
-        }
+        ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
     }
 } # VfpExtensionDetail()
 
@@ -1608,15 +1347,14 @@ function VMSwitchDetail {
     # See this command to get VFs on vSwitch
     # Get-NetAdapterSriovVf -SwitchId 2
 
-    foreach ($vSwitch in TryCmd {Get-VMSwitch}) {
-        $name = $vSwitch.Name
-        $type = $vSwitch.SwitchType
+    foreach ($vmSwitch in TryCmd {Get-VMSwitch}) {
+        $name = $vmSwitch.Name
+        $type = $vmSwitch.SwitchType
 
         $dir  = (Join-Path -Path $OutDir -ChildPath "VMSwitch.$type.$name")
         New-Item -ItemType directory -Path $dir | Out-Null
 
         Write-Host "Processing: $name"
-        Write-Host "----------------------------------------------"
         VfpExtensionDetail    -VMSwitchName $name -OutDir $dir
         VMSwitchWorker        -VMSwitchName $name -OutDir $dir
         ProtocolNicDetail     -VMSwitchName $name -OutDir $dir
@@ -1631,61 +1369,42 @@ function NetworkSummary {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
+    $dir = $OutDir
+
     $file = "Get-VMSwitch.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
-        [String []] $cmds = "Get-VMSwitch | Sort-Object Name",
-                            "Get-VMSwitch | Sort-Object Name | Format-Table -Property * -AutoSize | Out-String -Width $columns"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    [String []] $cmds = "Get-VMSwitch | Sort-Object Name",
+                        "Get-VMSwitch | Sort-Object Name | Format-Table -Property * -AutoSize | Out-String -Width $columns"
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMNetworkAdapter.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
-        [String []] $cmds = "Get-VMNetworkAdapter -All | Sort-Object Name | Format-Table -AutoSize",
-                            "Get-VMNetworkAdapter -All | Sort-Object Name | Format-Table -Property * -AutoSize | Out-String -Width $columns"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    [String []] $cmds = "Get-VMNetworkAdapter -All | Sort-Object Name | Format-Table -AutoSize",
+                        "Get-VMNetworkAdapter -All | Sort-Object Name | Format-Table -Property * -AutoSize | Out-String -Width $columns"
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapter.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
-        [String []] $cmds = "Get-NetAdapter -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -AutoSize",
-                            "Get-NetAdapter -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -Property * -AutoSize | Out-String -Width $columns"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    [String []] $cmds = "Get-NetAdapter -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -AutoSize",
+                        "Get-NetAdapter -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -Property * -AutoSize | Out-String -Width $columns"
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetAdapterStatistics.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
-        [String []] $cmds = "Get-NetAdapterStatistics -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -Autosize  | Out-String -Width $columns",
-                            "Get-NetAdapterStatistics -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -Property * -Autosize  | Out-String -Width $columns"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    [String []] $cmds = "Get-NetAdapterStatistics -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -Autosize  | Out-String -Width $columns",
+                        "Get-NetAdapterStatistics -IncludeHidden | Sort-Object InterfaceDescription | Format-Table -Property * -Autosize  | Out-String -Width $columns"
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetLbfoTeam.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
-        [String []] $cmds = "Get-NetLbfoTeam | Sort-Object InterfaceDescription",
-                            "Get-NetLbfoTeam | Sort-Object InterfaceDescription | Format-Table -Property * -AutoSize  | Out-String -Width $columns"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    [String []] $cmds = "Get-NetLbfoTeam | Sort-Object InterfaceDescription",
+                        "Get-NetLbfoTeam | Sort-Object InterfaceDescription | Format-Table -Property * -AutoSize  | Out-String -Width $columns"
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetIpAddress.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
-        [String []] $cmds = "Get-NetIpAddress | Format-Table -Autosize",
-                            "Get-NetIpAddress | Format-Table -Property * -AutoSize | Out-String -Width $columns"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    [String []] $cmds = "Get-NetIpAddress | Format-Table -Autosize",
+                        "Get-NetIpAddress | Format-Table -Property * -AutoSize | Out-String -Width $columns"
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "ipconfig.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
-        [String []] $cmds = "ipconfig",
-                            "ipconfig /allcompartments /all"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    [String []] $cmds = "ipconfig",
+                        "ipconfig /allcompartments /all"
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # NetworkSummary()
 
 function SMBDetail {
@@ -1694,61 +1413,43 @@ function SMBDetail {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $dir    = (Join-Path -Path $OutDir -ChildPath ("SMB"))
+    $dir = (Join-Path -Path $OutDir -ChildPath "SMB")
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "Get-SmbClientNetworkInterface.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-SmbClientNetworkInterface | Sort-Object FriendlyName | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-SmbClientNetworkInterface | Format-List  -Property *",
                         "Get-SmbClientNetworkInterface | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-SmbServerNetworkInterface.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-SmbServerNetworkInterface | Sort-Object FriendlyName | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-SmbServerNetworkInterface | Format-List  -Property *",
                         "Get-SmbServerNetworkInterface | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-SmbClientConfiguration.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-SmbClientConfiguration",
                         "Get-SmbClientConfiguration | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-SmbMultichannelConnection.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-SmbMultichannelConnection | Sort-Object Name | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-SmbMultichannelConnection -IncludeNotSelected | Format-List -Property *",
                         "Get-SmbMultichannelConnection -SmbInstance CSV -IncludeNotSelected | Format-List -Property *",
                         "Get-SmbMultichannelConnection -SmbInstance SBL -IncludeNotSelected | Format-List -Property *",
                         "Get-SmbMultichannelConnection | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-SmbMultichannelConstraint.txt"
-    $out = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-SmbMultichannelConstraint",
                         "Get-SmbMultichannelConstraint | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Smb-WindowsEvents.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-WinEvent -ListLog ""*SMB*"" | Format-List -Property *",
                         "Get-WinEvent -ListLog ""*SMB*"" | Get-WinEvent | ? Message -like ""*RDMA*"" | Format-List -Property *"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # SMBDetail()
 
 function NetSetupDetail {
@@ -1757,30 +1458,23 @@ function NetSetupDetail {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $dir    = (Join-Path -Path $OutDir -ChildPath ("NetSetup"))
+    $dir = (Join-Path -Path $OutDir -ChildPath ("NetSetup"))
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "NetSetup.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Test-Path $env:SystemRoot\System32\NetSetupMig.log",
                         "Test-Path $env:SystemRoot\Panther\setupact.log",
                         "Test-Path $env:SystemRoot\INF\setupapi.*",
                         "Test-Path $env:SystemRoot\logs\NetSetup"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     # Copy over the logs
     [String []] $cmds = "$env:SystemRoot\System32\NetSetupMig.log",
                         "$env:SystemRoot\Panther\setupact.log",
                         "$env:SystemRoot\INF\setupapi.*",
                         "$env:SystemRoot\logs\NetSetup"
-    ForEach($cmd in $cmds) {
-        if (Test-Path $cmd) {
-            $tcmd = "Copy-Item $cmd $dir -recurse -verbose 4>&1"
-            ExecCommand -Trusted -Command ($tcmd) -Output $out
-        }
-    }
+    $cmds = $cmds | foreach {"Copy-Item $_ $dir -Recurse -Verbose 4>&1"}
+    ExecCommandsAsync -Trusted -OutDir $dir -File $file -Commands $cmds
 } # NetSetupDetail()
 
 function HNSDetail {
@@ -1789,32 +1483,32 @@ function HNSDetail {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $dir    = (Join-Path -Path $OutDir -ChildPath "HNS")
+    try {
+        Get-Service "hns" -ErrorAction Stop
+    } catch {
+        Write-Host "HNSDetail: hns service not found, skipping."
+        return
+    }
+
+    $dir = (Join-Path -Path $OutDir -ChildPath "HNS")
     New-Item -ItemType Directory -Path $dir | Out-Null
 
+    # Data collected before stop -> start must be collected synchronously
+
     $file = "HNSRegistry-1.txt"
-    $out  = (Join-Path $dir $file)
     [String []] $cmds = "Get-ChildItem HKLM:\SYSTEM\CurrentControlSet\Services\hns -Recurse",
                         "Get-ChildItem HKLM:\SYSTEM\CurrentControlSet\Services\vmsmp -Recurse"
-    foreach ($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-HNSNetwork-1.txt"
-    $out  = (Join-Path $dir $file)
     [String []] $cmds = "Get-HNSNetwork | ConvertTo-Json -Depth 10",
                         "Get-HNSNetwork | Get-Member"
-    foreach ($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-HNSEndpoint-1.txt"
-    $out = (Join-Path $dir $file)
     [String []] $cmds = "Get-HNSEndpoint | ConvertTo-Json -Depth 10",
                         "Get-HNSEndpoint | Get-Member"
-    foreach ($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     # HNS service stop -> start occurs after capturing the current HNS state info.
     $hnsRunning = (Get-Service hns).Status -eq "Running"
@@ -1825,43 +1519,30 @@ function HNSDetail {
         }
 
         $file = "HNSData.txt"
-        $out  = (Join-Path $dir $file)
         [String []] $cmds = "Copy-Item ""$env:ProgramData\Microsoft\Windows\HNS\HNS.data"" $dir 4>&1"
-        foreach ($cmd in $cmds) {
-            ExecCommand -Command ($cmd) -Output $out
-        }
+        ExecCommands -OutDir $dir -File $file -Commands $cmds
     } finally {
         if ($hnsRunning) {
             net start hns
         }
     }
 
-
     # Acquire all settings again after stop -> start services
+    # From now on we can collect data asynchronously.
     $file = "HNSRegistry-2.txt"
-    $out  = (Join-Path $dir $file)
     [String []] $cmds = "Get-ChildItem HKLM:\SYSTEM\CurrentControlSet\Services\hns -Recurse",
                         "Get-ChildItem HKLM:\SYSTEM\CurrentControlSet\Services\vmsmp -Recurse"
-    foreach ($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-HNSNetwork-2.txt"
-    $out  = (Join-Path $dir $file)
     [String []] $cmds = "Get-HNSNetwork | ConvertTo-Json -Depth 10",
                         "Get-HNSNetwork | Get-Member"
-    foreach ($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-HNSEndpoint-2.txt"
-    $out = (Join-Path $dir $file)
     [String []] $cmds = "Get-HNSEndpoint | ConvertTo-Json -Depth 10",
                         "Get-HNSEndpoint | Get-Member"
-    foreach ($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
-
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     #netsh trace start scenario=Virtualization provider=Microsoft-Windows-tcpip provider=Microsoft-Windows-winnat capture=yes captureMultilayer=yes capturetype=both report=disabled tracefile=$dir\server.etl overwrite=yes
     #Start-Sleep 120
@@ -1874,48 +1555,36 @@ function QosDetail {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $dir    = (Join-Path -Path $OutDir -ChildPath ("NetQoS"))
+    $dir = (Join-Path -Path $OutDir -ChildPath "NetQoS")
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "Get-NetQosDcbxSetting.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetQosDcbxSetting",
                         "Get-NetQosDcbxSetting | Format-List  -Property *",
                         "Get-NetQosDcbxSetting | Format-Table -Property *  -AutoSize | Out-String -Width $columns",
                         "Get-NetQosDcbxSetting | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetQosFlowControl.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetQosFlowControl",
                         "Get-NetQosFlowControl | Format-List  -Property *",
                         "Get-NetQosFlowControl | Format-Table -Property *  -AutoSize | Out-String -Width $columns",
                         "Get-NetQosFlowControl | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetQosPolicy.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetQosPolicy",
                         "Get-NetQosPolicy | Format-List  -Property *",
                         "Get-NetQosPolicy | Format-Table -Property *  -AutoSize | Out-String -Width $columns",
                         "Get-NetQosPolicy | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetQosTrafficClass.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-NetQosTrafficClass",
                         "Get-NetQosTrafficClass | Format-List  -Property *",
                         "Get-NetQosTrafficClass | Format-Table -Property *  -AutoSize | Out-String -Width $columns",
                         "Get-NetQosTrafficClass | Get-Member"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # QosDetail()
 
 function ServicesDrivers {
@@ -1924,45 +1593,30 @@ function ServicesDrivers {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $dir    = (Join-Path -Path $OutDir -ChildPath ("ServicesDrivers"))
+    $dir = (Join-Path -Path $OutDir -ChildPath "ServicesDrivers")
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "sc.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "sc.exe queryex vmsp",
                         "sc.exe queryex vmsproxy"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-Service.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-Service ""*"" | Sort-Object Name | Format-Table -AutoSize",
                         "Get-Service ""*"" | Sort-Object Name | Format-Table -Property * -AutoSize"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-WindowsDriver.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-WindowsDriver -Online -All" # very slow, -Trusted to skip validation
-    ForEach($cmd in $cmds) {
-        ExecCommand -Trusted -Command $cmd -Output $out
-    }
+    ExecCommandsAsync -Trusted -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-WindowsEdition.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-WindowsEdition -Online"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-WmiObject.Win32_PnPSignedDriver.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-WmiObject Win32_PnPSignedDriver| select devicename, driverversion"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # ServicesDrivers()
 
 function NetshTrace {
@@ -1971,7 +1625,7 @@ function NetshTrace {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $dir    = (Join-Path -Path $OutDir -ChildPath ("Netsh"))
+    $dir = (Join-Path -Path $OutDir -ChildPath "Netsh")
     New-Item -ItemType directory -Path $dir | Out-Null
 
     <# Deprecated / DELETEME
@@ -1985,22 +1639,18 @@ function NetshTrace {
     #$wpp_vswitch  = "{1F387CBC-6818-4530-9DB6-5F1058CD7E86}"
     #$wpp_ndis     = "{DD7A21E6-A651-46D4-B7C2-66543067B869}"
 
-
     # The sequence below triggers the ETW providers to dump their internal traces when the session starts.  Thus allowing for capturing a
     # snapshot of their logs/traces.
     #
     # NOTE: This does not cover IFR (in-memory) traces.  More work needed to address said traces.
     $file = "NetRundown.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "New-NetEventSession    NetRundown -CaptureMode SaveToFile -LocalFilePath $dir\NetRundown.etl",
                         "Add-NetEventProvider   ""{1F387CBC-6818-4530-9DB6-5F1058CD7E86}"" -SessionName NetRundown -Level 1 -MatchAnyKeyword 0x10000",
                         "Add-NetEventProvider   ""{DD7A21E6-A651-46D4-B7C2-66543067B869}"" -SessionName NetRundown -Level 1 -MatchAnyKeyword 0x2",
                         "Start-NetEventSession  NetRundown",
                         "Stop-NetEventSession   NetRundown",
                         "Remove-NetEventSession NetRundown"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Trusted -Command $cmd -Output $out
-    }
+    ExecCommands -Trusted -OutDir $dir -File $file -Commands $cmds
 
     #
     # The ETL file can be converted to text using the following command:
@@ -2008,14 +1658,10 @@ function NetshTrace {
     #    Specifying a path to the TMF symbols. Output is attached.
 
     $file = "NetshDump.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "netsh dump"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommands -Trusted -OutDir $dir -File $file -Commands $cmds
 
     $file = "NetshStatistics.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "netsh interface ipv4 show icmpstats",
                         "netsh interface ipv4 show ipstats",
                         "netsh interface ipv4 show tcpstats",
@@ -2023,22 +1669,16 @@ function NetshTrace {
                         "netsh interface ipv6 show ipstats",
                         "netsh interface ipv6 show tcpstats",
                         "netsh interface ipv6 show udpstats"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommands -Trusted -OutDir $dir -File $file -Commands $cmds
 
-    #NetSetup, binding map, setupact logs amongst other things needed by NDIS folks.
     Write-Host "`n"
     Write-Host "Processing..."
     $file = "NetshTrace.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "netsh -?",
                         "netsh trace show scenarios",
                         "netsh trace show providers",
-                        "netsh trace  diagnose scenario=NetworkSnapshot mode=Telemetry saveSessionTrace=yes report=yes ReportFile=$dir\Snapshot.cab"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Trusted -Command $cmd -Output $out
-    }
+                        "netsh trace diagnose scenario=NetworkSnapshot mode=Telemetry saveSessionTrace=yes report=yes ReportFile=$dir\Snapshot.cab"
+    ExecCommands -Trusted -OutDir $dir -File $file -Commands $cmds
 } # NetshTrace()
 
 function OneX {
@@ -2047,16 +1687,13 @@ function OneX {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $dir    = (Join-Path -Path $OutDir -ChildPath ("OneX"))
+    $dir = (Join-Path -Path $OutDir -ChildPath "OneX")
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "OneX.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "netsh lan show interface",
                         "netsh lan show profile"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }    
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 }
 
 function Counters {
@@ -2069,33 +1706,21 @@ function Counters {
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "CounterSetName.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-Counter -ListSet * | Sort-Object CounterSetName | Select-Object CounterSetName | Out-String -Width $columns"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     $file = "CounterSetName.Paths.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "(Get-Counter -ListSet * | Sort-Object CounterSetName).Paths | Out-String -Width $columns"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     $file = "CounterSetName.PathsWithInstances.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "(Get-Counter -ListSet * | Sort-Object CounterSetName).PathsWithInstances | Out-String -Width $columns"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     $file = "CounterSet.Property.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "(Get-Counter -ListSet * | Sort-Object CounterSetName) | Format-List -Property * | Out-String -Width $columns",
                         "(Get-Counter -ListSet * | Sort-Object CounterSetName) | Format-Table -Property * | Out-String -Width $columns"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     $file = "CounterDetail" # used with 2 different extensions
     $out  = (Join-Path -Path $dir -ChildPath $file)
@@ -2104,8 +1729,7 @@ function Counters {
     $cntrPaths = Get-Counter -ListSet $cntrList -ErrorAction SilentlyContinue | Sort-Object CounterSetName | ForEach-Object { $_.Paths }
 
     Write-Host "Querying Perf Counters..."
-    # TODO should keep taking samples until all other jobs complete
-    $cntrReadings = Get-Counter -Counter $cntrPaths -MaxSamples 5 -SampleInterval 10 -ErrorAction SilentlyContinue
+    $cntrReadings = Get-Counter -Counter $cntrPaths -MaxSamples 5 -SampleInterval 8 -ErrorAction SilentlyContinue
     Write-Host "Exporting Results..."
     $cntrReadings | Export-Counter -Path "$out.blg" -FileFormat BLG
     $cntrReadings | Export-Counter -Path "$out.csv" -FileFormat CSV
@@ -2117,12 +1741,11 @@ function HwErrorReport {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
+    $dir = $OutDir
+
     $file = "WER.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
     [String []] $cmds = "copy-item $env:ProgramData\Microsoft\Windows\WER $outdir -recurse -verbose 4>&1"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Trusted -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -Trusted -OutDir $dir -File $file -Commands $cmds
 } # HwErrorReport()
 
 function LogsReport {
@@ -2131,12 +1754,11 @@ function LogsReport {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
+    $dir = $OutDir
+
     $file = "WinEVT.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
     [String []] $cmds = "Copy-Item $env:SystemRoot\System32\winevt $outdir -Recurse -Verbose 4>&1"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Trusted -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -Trusted -OutDir $dir -File $file -Commands $cmds
 } # LogsReport()
 
 function Metadata {
@@ -2146,18 +1768,16 @@ function Metadata {
         [parameter(Mandatory=$true)] [Hashtable] $Params
     )
 
+    $dir  = $OutDir
+
     $file = "Metadata.txt"
-    $out = (Join-Path -Path $OutDir -ChildPath $file)
-
+    $out = Join-Path $dir $file
     $paramString = if ($Params.Count -eq 0) {"None`n`n"} else {"`n$($Params | Out-String)"}
-
     Write-Output "Version: $version" | Out-File -Encoding ascii -Append $out
     Write-Output "Parameters: $paramString" | Out-File -Encoding ascii -Append $out
 
     [String []] $cmds = "Get-FileHash -Path $PSCommandPath -Algorithm ""SHA256"" | Format-List -Property * | Out-String -Width $columns"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommands -OutDir $dir -File $file -Commands $cmds
 } # Metadata()
 
 function Environment {
@@ -2166,24 +1786,20 @@ function Environment {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
+    $dir = $OutDir
+
     $file = "Environment.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
     [String []] $cmds = "Get-ItemProperty -Path ""HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion""",
                         "date",
                         #"Get-WinEvent -ProviderName eventlog | Where-Object {$_.Id -eq 6005 -or $_.Id -eq 6006}",
                         "wmic os get lastbootuptime",
                         "wmic cpu get name",
                         "systeminfo"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Verifier.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
     [String []] $cmds = "verifier /querysettings"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # Environment()
 
 function HostInfo {
@@ -2192,36 +1808,26 @@ function HostInfo {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
+    $dir = $OutDir
+
     $file = "Get-HotFix.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
     [String []] $cmds = "get-hotfix | Sort-Object InstalledOn | Format-Table -AutoSize | Out-String -Width $columns",
                         "get-hotfix | Sort-Object InstalledOn | Format-Table -Property * -AutoSize | Out-String -Width $columns"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMHostSupportedVersion.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
     [String []] $cmds = "Get-VMHostSupportedVersion | Format-Table -AutoSize | Out-String -Width $columns",
                         "Get-VMHostSupportedVersion | Format-List -Property *"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-VMHostNumaNode.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
     [String []] $cmds = "Get-VMHostNumaNode"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     <#
     $file = "Get-VMHostNumaNodeStatus.txt"
-    $out  = (Join-Path -Path $OutDir -ChildPath $file)
     [String []] $cmds = "Get-VMHostNumaNodeStatus"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
     #>
 } # HostInfo()
 
@@ -2240,10 +1846,7 @@ function CustomModule {
     New-Item -ItemType Directory -Path $CustomModule | Out-Null
 
     $file = "ExtraCommands.txt"
-    $out  = (Join-Path $CustomModule $file)
-    foreach ($cmd in $Commands) {
-        ExecCommand -Command $cmd -Output $out
-    }
+    ExecCommands -OutDir $CustomModule -File $file -Commands $Commands
 } # CustomModule()
 
 #
@@ -2330,7 +1933,7 @@ function CreateZip {
         [parameter(Mandatory=$true)] [String] $Out
     )
 
-    If(Test-path $Out) {
+    if (Test-path $Out) {
         Remove-item $Out
     }
 
@@ -2345,16 +1948,12 @@ function Sanity {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $dir  = (Join-Path -Path $OutDir -ChildPath ("Sanity"))
+    $dir  = (Join-Path -Path $OutDir -ChildPath "Sanity")
     New-Item -ItemType directory -Path $dir | Out-Null
 
     $file = "Get-ChildItem.txt"
-    $out  = (Join-Path -Path $dir -ChildPath $file)
     [String []] $cmds = "Get-ChildItem -Path $OutDir -Exclude $file -Recurse | Get-FileHash | Format-Table -AutoSize | Out-String -Width $columns"
-    ForEach($cmd in $cmds) {
-        ExecCommand -Command ($cmd) -Output $out
-    }
-
+    ExecCommands -OutDir $dir -File $file -Commands $cmds
 } # Sanity()
 
 function Completion {
@@ -2395,7 +1994,6 @@ function Completion {
     Write-Host "`n"
 } # Completion()
 
-
 #===============================================
 # Main Program
 #===============================================
@@ -2409,15 +2007,15 @@ function Get-NetView {
         [parameter(Mandatory=$false)]
         [ScriptBlock[]] $ExtraCommands = @(),
 
-        [ValidateRange(0, [Int]::MaxValue)]
-        [Int] $MaxThreads = 0,
+        [ValidateRange(1, 10)]
+        [Int] $MaxThreads = 4,
 
         [parameter(Mandatory=$false)]
         [Switch] $SkipAdminCheck = $false
     )
 
     $start = Get-Date
-    $version = "2018.09.05.0" # Version within date context
+    $version = "2018.09.07.0" # Version within date context
 
     # Input Validation
     CheckAdminPrivileges $SkipAdminCheck
@@ -2428,47 +2026,43 @@ function Get-NetView {
 
     # Start Run
     try {
-        CustomModule      -OutDir $workDir -Commands $ExtraCommands
+        CustomModule -OutDir $workDir -Commands $ExtraCommands
 
-        Initialize-GlobalThreadPool -MaxThreads $MaxThreads
+        Open-GlobalThreadPool -MaxThreads $MaxThreads
 
-        # concurrent execution of slow commands
         $threads = if ($true) {
-            Start-Thread ${function:ServicesDrivers} -Params @{OutDir=$workDir}
-            Start-Thread ${function:NetshTrace}      -Params @{OutDir=$workDir}
-            Start-Thread ${function:Counters}        -Params @{OutDir=$workDir}
+            Start-Thread ${function:NetshTrace} -Params @{OutDir=$workDir}
+            Start-Thread ${function:Counters}   -Params @{OutDir=$workDir}
+
+            Metadata          -OutDir $workDir  -Params $PSBoundParameters
+            Environment       -OutDir $workDir
+            ServicesDrivers   -OutDir $workDir
+
+            NetworkSummary    -OutDir $workDir
+            HwErrorReport     -OutDir $workDir
+            LogsReport        -OutDir $workDir
+
+            NetSetupDetail    -OutDir $workDir
+            VMSwitchDetail    -OutDir $workDir
+            LbfoDetail        -OutDir $workDir
+            NativeNicDetail   -OutDir $workDir
+            OneX              -OutDir $workDir
+
+            QosDetail         -OutDir $workDir
+            SMBDetail         -OutDir $workDir
+            NetIp             -OutDir $workDir
+            NetNat            -OutDir $workDir
+            HNSDetail         -OutDir $workDir
         }
 
-        Metadata          -OutDir $workDir -Params $PSBoundParameters
-        Environment       -OutDir $workDir
-
-        NetworkSummary    -OutDir $workDir
-        HwErrorReport     -OutDir $workDir
-        LogsReport        -OutDir $workDir
-
-        NetSetupDetail    -OutDir $workDir
-        VMSwitchDetail    -OutDir $workDir
-        LbfoDetail        -OutDir $workDir
-        NativeNicDetail   -OutDir $workDir
-        OneX              -OutDir $workDir
-
-        QosDetail         -OutDir $workDir
-        SMBDetail         -OutDir $workDir
-        NetIp             -OutDir $workDir
-        NetNat            -OutDir $workDir
-        HNSDetail         -OutDir $workDir
-
-        # show thread output
-        $threads | foreach {StreamThread $_}
+        # Show thread output, and wait for them all to complete
+        $threads | foreach {Show-Thread $_}
 
         # Tamper Detection
         Sanity            -OutDir $workDir
     } catch {
         throw $error[0] # try finally obfuscates error
     } finally {
-        Write-Host "Removing background threads..."
-        $threads | foreach {Remove-Thread $_}
-
         Close-GlobalThreadPool
     }
 


### PR DESCRIPTION
### Overview
This change adds per-file multithreading, using a global RunspacePool to manage the threads.
The max number of simultaneous threads is limited to 5, and can be changed with the new `-MaxThreads` parameter (up to 16). The numbers are somewhat arbitrary, but more than 5 threads will generally see marginal benefits. We can change it to scale with available hardware at a later date.

Exceptions to per-file multithreading are:
`CustomModule`, `Metadata`, and `Sanity` are run synchronously in the main thread.
`NetshTrace` and `Counters` run synchronously in their own thread. (Potential for future optimizations here).
`HNSDetail` runs synchronously in the main thread before start/stop of hns service, and asynchronously afterwards.

### Other Changes
* Execute "Untrusted" commands once instead of twice.
* Reduced the number of counters queried to deal with exponential time complexity of `Get-Counter`.
* Added `ExecCommands()` and `ExecCommandsAsync()` to abstract away common control structures.
* Skip HNSDetail if the HNS service is not found.
* Removed `Get-Member` calls. They weren't all working correctly, and it's not worth auditing them.
* Removed colored text output from ExecCommand, because color information from threads is lost. We can bring it back later, with a different implementation.
* Combine certain worker/detail functions together for simplicity.
* Cache cmdlet output in certain commands to avoid extra calls.
* Various formatting and consistency improvements.

### Bug Fixes
* Identify {VMs, VMNics, VMSwitches} by id, to correctly handle objects with the same name.
* Moved some cmdlets from `VMSwitchWorker` to the correct location.
* Fixed issue where HostVNics are processed twice.

### Performance
System is one of my test servers with:
8 Physical Nics
6 Host VNics
6 VMSwitches (4 External / 2 Internal)
3 VMs (all off)
4 VMNics

| Get-NetView | Execution Time |
|---|---|
| Inbox  | 30m 16s |
| 2 threads | 3m 50s |
| 4 threads | 2m 36s |
| 5 threads (default) | 2m 14s |
| 8 threads | 1m 51s |
| 16 threads | 1m 54s |

The minimum possible runtime would be around 1m 30s due to the netsh capture.