### PR TITLE
Replacing Start-BitsTransfer Call

### DIFF
--- a/Kubernetes/flannel/l2bridge/start.ps1
+++ b/Kubernetes/flannel/l2bridge/start.ps1
@@ -61,7 +61,7 @@ SetupDirectories
 $helper = "c:\k\helper.psm1"
 if (!(Test-Path $helper))
 {
-    wget -Url https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -OutFile $BaseDir\helper.psm1
+    wget https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -OutFile $BaseDir\helper.psm1
 }
 ipmo $helper
 

--- a/Kubernetes/flannel/l2bridge/start.ps1
+++ b/Kubernetes/flannel/l2bridge/start.ps1
@@ -1,4 +1,4 @@
-﻿Param(
+Param(
     [parameter(Mandatory = $true)] $ClusterCIDR,
     [parameter(Mandatory = $true)] $ManagementIP,
     [parameter(Mandatory = $true)] $KubeDnsServiceIP,
@@ -61,7 +61,7 @@ SetupDirectories
 $helper = "c:\k\helper.psm1"
 if (!(Test-Path $helper))
 {
-    Start-BitsTransfer https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -Destination c:\k\helper.psm1
+    wget -Url https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -OutFile $BaseDir\helper.psm1
 }
 ipmo $helper
 


### PR DESCRIPTION
Start-BitsTransfer fails when used in userdata in an AWS EC2 instance since no user is logged in (not sure why this is the case). Replaced the call with a call to `wget`, but I'm not a Powershell expert, perhaps an `Invoke-WebRequest` might be better suited here.