### PR TITLE
Better Flannel Startup

### DIFF
--- a/Kubernetes/flannel/l2bridge/start.ps1
+++ b/Kubernetes/flannel/l2bridge/start.ps1
@@ -90,7 +90,7 @@ if(!(Get-HnsNetwork | ? Name -EQ "External"))
 Start-Sleep 5
 $hasFlannelCompleted = $false
 while(-not $hasFlannelCompleted) {
-    $job = Start-Job -ScriptBlock {StartFlanneld -ipaddress $env:HostIP -NetworkName $NetworkName}
+    $job = Start-Job -ScriptBlock {StartFlanneld -ipaddress $ManagementIP -NetworkName $NetworkName}
     $job | Wait-Job -Timeout 60
     $job | Where-Object {$_.State -ne "Completed"} | Stop-Job
 


### PR DESCRIPTION
Adding a retry loop around the flannel startup as it seems to often times get stuck at "waiting for network to be created" which can be solved by simply killing it and restarting the job.

Added a hardcoded 60 second timeout for flannel, could be supplied as a parameter.