### PR TITLE
Making it easy to deploy & use a fork of this repo

### DIFF
--- a/Kubernetes/containerd/start.ps1
+++ b/Kubernetes/containerd/start.ps1
@@ -27,6 +27,12 @@ $kubeDnsSuffix="svc.cluster.local"
 $kubeletConfigPath = Join-Path $kubernetesPath "kubelet-config.yaml"
 $cniConfig = Join-Path $cniConfigDir "cni.conf"
 
+$GithubSDNRepository = 'Microsoft/SDN'
+if ((Test-Path env:GITHUB_SDN_REPOSITORY) -and ($env:GITHUB_SDN_REPOSITORY -ne ''))
+{
+    $GithubSDNRepository = $env:GITHUB_SDN_REPOSITORY
+}
+
 # create all the necessary directories if they don't already exist
 New-Item -ItemType Directory -Path $kubernetesPath -Force > $null
 New-Item -ItemType Directory -Path $cniConfigDir -Force > $null
@@ -41,7 +47,7 @@ Function GetHelper() {
     $helper = Join-Path $kubernetesPath helper.psm1
     if (!(Test-Path $helper))
     {
-        Start-BitsTransfer https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -Destination $helper
+        Start-BitsTransfer "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/helper.psm1" -Destination $helper
     }
     Import-Module $helper
 }
@@ -54,9 +60,9 @@ Function DownloadAllFiles() {
     DownloadFile "https://storage.googleapis.com/kubernetes-release/release/v$KubernetesVersion/bin/windows/amd64/kube-proxy.exe" (Join-Path $kubernetesPath kube-proxy.exe)
 
     # download cni binaries
-    DownloadFile https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/cni/flannel.exe $cniDir\flannel.exe
-    DownloadFile https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/cni/host-local.exe $cniDir\host-local.exe
-    DownloadFile https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/cni/win-bridge.exe $cniDir\win-bridge.exe
+    DownloadFile "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/l2bridge/cni/flannel.exe" $cniDir\flannel.exe
+    DownloadFile "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/l2bridge/cni/host-local.exe" $cniDir\host-local.exe
+    DownloadFile "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/l2bridge/cni/win-bridge.exe" $cniDir\win-bridge.exe
 
     # download available cri binaries
     if(-not (Test-Path (Join-Path $containerdPath crictl.exe))) {
@@ -66,8 +72,8 @@ Function DownloadAllFiles() {
     DownloadFile https://github.com/Microsoft/hcsshim/releases/download/v0.8.4/runhcs.exe $containerdPath\runhcs.exe
 
     # download SDN scripts and configs
-    DownloadFile https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 (Join-Path $kubernetesPath hns.psm1)
-    DownloadFile https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/net-conf.json (Join-Path $kubernetesPath net-conf.json)
+    DownloadFile "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/hns.psm1" (Join-Path $kubernetesPath hns.psm1)
+    DownloadFile "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/l2bridge/net-conf.json" (Join-Path $kubernetesPath net-conf.json)
     Copy-Item (Join-Path $kubernetesPath net-conf.json) $flanneldConfPath
 
     # download flannel
@@ -75,7 +81,7 @@ Function DownloadAllFiles() {
     Copy-Item (Join-Path $kubernetesPath flanneld.exe) $flanneldPath
 
     # download containerd's config
-    DownloadFile https://github.com/Microsoft/SDN/raw/master/Kubernetes/containerd/containerd-config.toml $containerdPath\config.toml
+    DownloadFile "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/containerd/containerd-config.toml" $containerdPath\config.toml
 
     # download LCOW
     if(-not (Test-Path (Join-Path $lcowPath kernel))) {

--- a/Kubernetes/flannel/start-kubelet.ps1
+++ b/Kubernetes/flannel/start-kubelet.ps1
@@ -5,10 +5,16 @@ Param(
     [switch] $RegisterOnly
 )
 
+$GithubSDNRepository = 'Microsoft/SDN'
+if ((Test-Path env:GITHUB_SDN_REPOSITORY) -and ($env:GITHUB_SDN_REPOSITORY -ne ''))
+{
+    $GithubSDNRepository = $env:GITHUB_SDN_REPOSITORY
+}
+
 $helper = "c:\k\helper.psm1"
 if (!(Test-Path $helper))
 {
-    Start-BitsTransfer https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -Destination c:\k\helper.psm1
+    Start-BitsTransfer "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/helper.psm1" -Destination c:\k\helper.psm1
 }
 ipmo $helper
 

--- a/Kubernetes/flannel/start.ps1
+++ b/Kubernetes/flannel/start.ps1
@@ -12,6 +12,12 @@ $BaseDir = "c:\k"
 $NetworkMode = $NetworkMode.ToLower()
 $NetworkName = "cbr0"
 
+$GithubSDNRepository = 'Microsoft/SDN'
+if ((Test-Path env:GITHUB_SDN_REPOSITORY) -and ($env:GITHUB_SDN_REPOSITORY -ne ''))
+{
+    $GithubSDNRepository = $env:GITHUB_SDN_REPOSITORY
+}
+
 if ($NetworkMode -eq "overlay")
 {
     $NetworkName = "vxlan0"
@@ -21,14 +27,14 @@ if ($NetworkMode -eq "overlay")
 $helper = "c:\k\helper.psm1"
 if (!(Test-Path $helper))
 {
-    Start-BitsTransfer https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -Destination c:\k\helper.psm1
+    Start-BitsTransfer "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/helper.psm1" -Destination c:\k\helper.psm1
 }
 ipmo $helper
 
 $install = "c:\k\install.ps1"
 if (!(Test-Path $install))
 {
-    Start-BitsTransfer https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/install.ps1 -Destination c:\k\install.ps1
+    Start-BitsTransfer "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/install.ps1" -Destination c:\k\install.ps1
 }
 
 # Download files, move them, & prepare network

--- a/Kubernetes/windows/debug/collectlogs.ps1
+++ b/Kubernetes/windows/debug/collectlogs.ps1
@@ -2,21 +2,27 @@ Param(
     [parameter(Mandatory = $false)] [string] $Network = "L2Bridge"
 )
 
+$GithubSDNRepository = 'Microsoft/SDN'
+if ((Test-Path env:GITHUB_SDN_REPOSITORY) -and ($env:GITHUB_SDN_REPOSITORY -ne ''))
+{
+    $GithubSDNRepository = $env:GITHUB_SDN_REPOSITORY
+}
+
 $BaseDir = "c:\k\debug"
 md $BaseDir -ErrorAction Ignore
 
 $helper = "$BaseDir\helper.psm1"
 if (!(Test-Path $helper))
 {
-    Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -OutFile $BaseDir\helper.psm1
+    Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/helper.psm1" -OutFile $BaseDir\helper.psm1
 }
 ipmo $helper
 
-DownloadFile -Url  "https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/debug/dumpVfpPolicies.ps1" -Destination $BaseDir\dumpVfpPolicies.ps1
-DownloadFile -Url "https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/hns.psm1" -Destination $BaseDir\hns.psm1
-DownloadFile -Url "https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/debug/starthnstrace.cmd" -Destination $BaseDir\starthnstrace.cmd
-DownloadFile -Url "https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/debug/startpacketcapture.cmd" -Destination $BaseDir\startpacketcapture.cmd
-DownloadFile -Url  "https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/debug/stoppacketcapture.cmd" -Destination $BaseDir\stoppacketcapture.cmd
+DownloadFile -Url  "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/debug/dumpVfpPolicies.ps1" -Destination $BaseDir\dumpVfpPolicies.ps1
+DownloadFile -Url "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/hns.psm1" -Destination $BaseDir\hns.psm1
+DownloadFile -Url "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/debug/starthnstrace.cmd" -Destination $BaseDir\starthnstrace.cmd
+DownloadFile -Url "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/debug/startpacketcapture.cmd" -Destination $BaseDir\startpacketcapture.cmd
+DownloadFile -Url  "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/debug/stoppacketcapture.cmd" -Destination $BaseDir\stoppacketcapture.cmd
 
 ipmo $BaseDir\hns.psm1
 

--- a/Kubernetes/windows/debug/dumpVfpPolicies.ps1
+++ b/Kubernetes/windows/debug/dumpVfpPolicies.ps1
@@ -3,17 +3,23 @@ param(
    [string]$outfile = "vfprules.txt"
   )
 
+$GithubSDNRepository = 'Microsoft/SDN'
+if ((Test-Path env:GITHUB_SDN_REPOSITORY) -and ($env:GITHUB_SDN_REPOSITORY -ne ''))
+{
+    $GithubSDNRepository = $env:GITHUB_SDN_REPOSITORY
+}
+
 $BaseDir = "c:\k\debug"
 md $BaseDir -ErrorAction Ignore
 
 $helper = "$BaseDir\helper.psm1"
 if (!(Test-Path $helper))
 {
-    Start-BitsTransfer https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -Destination $BaseDir\helper.psm1
+    Start-BitsTransfer "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/helper.psm1" -Destination $BaseDir\helper.psm1
 }
 ipmo $helper
 
-DownloadFile -Url "https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/debug/VFP.psm1" -Destination $BaseDir\VFP.psm1
+DownloadFile -Url "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/debug/VFP.psm1" -Destination $BaseDir\VFP.psm1
 ipmo $BaseDir\VFP.psm1
 
 $ports = Get-VfpPorts -SwitchName $switchName

--- a/Kubernetes/windows/install.ps1
+++ b/Kubernetes/windows/install.ps1
@@ -7,6 +7,12 @@ Param(
     [parameter(Mandatory = $false)] $LogDir = "C:\k"
 )
 
+$GithubSDNRepository = 'Microsoft/SDN'
+if ((Test-Path env:GITHUB_SDN_REPOSITORY) -and ($env:GITHUB_SDN_REPOSITORY -ne ''))
+{
+    $GithubSDNRepository = $env:GITHUB_SDN_REPOSITORY
+}
+
 $NetworkName = "cbr0"
 if ($NetworkMode -eq "overlay")
 {
@@ -39,29 +45,29 @@ function DownloadFlannelBinaries()
 function DownloadCniBinaries($NetworkMode)
 {
     Write-Host "Downloading CNI binaries"
-    DownloadFile -Url  "https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/$NetworkMode/net-conf.json" -Destination $BaseDir\net-conf.json
-    DownloadFile -Url "https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/$NetworkMode/cni/config/cni.conf" -Destination $BaseDir\cni\config\cni.conf
-    DownloadFile -Url  "https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/cni/flannel.exe" -Destination $BaseDir\cni\flannel.exe
-    DownloadFile -Url  "https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/cni/host-local.exe" -Destination $BaseDir\cni\host-local.exe
+    DownloadFile -Url  "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/$NetworkMode/net-conf.json" -Destination $BaseDir\net-conf.json
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/$NetworkMode/cni/config/cni.conf" -Destination $BaseDir\cni\config\cni.conf
+    DownloadFile -Url  "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/l2bridge/cni/flannel.exe" -Destination $BaseDir\cni\flannel.exe
+    DownloadFile -Url  "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/l2bridge/cni/host-local.exe" -Destination $BaseDir\cni\host-local.exe
 
     if ($NetworkMode -eq "l2bridge")
     {
-        DownloadFile -Url  "https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/l2bridge/cni/win-bridge.exe" -Destination $BaseDir\cni\win-bridge.exe
+        DownloadFile -Url  "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/l2bridge/cni/win-bridge.exe" -Destination $BaseDir\cni\win-bridge.exe
     }
     elseif ($NetworkMode -eq "overlay"){
-        DownloadFile -Url  "https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/overlay/cni/win-overlay.exe" -Destination $BaseDir\cni\win-overlay.exe
+        DownloadFile -Url  "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/overlay/cni/win-overlay.exe" -Destination $BaseDir\cni\win-overlay.exe
     }
 }
 
 function DownloadWindowsKubernetesScripts
 {
     Write-Host "Downloading Windows Kubernetes scripts"
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -Destination $BaseDir\hns.psm1
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/InstallImages.ps1 -Destination $BaseDir\InstallImages.ps1
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/Dockerfile -Destination $BaseDir\Dockerfile
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/stop.ps1 -Destination $BaseDir\stop.ps1
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/start-kubelet.ps1 -Destination $BaseDir\start-Kubelet.ps1
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/flannel/start-kubeproxy.ps1 -Destination $BaseDir\start-Kubeproxy.ps1
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/hns.psm1" -Destination $BaseDir\hns.psm1
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/InstallImages.ps1" -Destination $BaseDir\InstallImages.ps1
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/Dockerfile" -Destination $BaseDir\Dockerfile
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/stop.ps1" -Destination $BaseDir\stop.ps1
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/start-kubelet.ps1" -Destination $BaseDir\start-kubelet.ps1
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/start-kubeproxy.ps1" -Destination $BaseDir\start-Kubeproxy.ps1
 }
 
 function DownloadAllFiles($NetworkMode)
@@ -78,7 +84,7 @@ $helper = "c:\k\helper.psm1"
 
 if (!(Test-Path $helper))
 {
-    Start-BitsTransfer https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -Destination c:\k\helper.psm1
+    Start-BitsTransfer "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/helper.psm1" -Destination c:\k\helper.psm1
 }
 ipmo $helper
 

--- a/Kubernetes/windows/start.ps1
+++ b/Kubernetes/windows/start.ps1
@@ -3,24 +3,30 @@ Param(
     [parameter(Mandatory = $false)] $clusterCIDR="192.168.0.0/16"
 )
 
+$GithubSDNRepository = 'Microsoft/SDN'
+if ((Test-Path env:GITHUB_SDN_REPOSITORY) -and ($env:GITHUB_SDN_REPOSITORY -ne ''))
+{
+    $GithubSDNRepository = $env:GITHUB_SDN_REPOSITORY
+}
+
 function DownloadCniBinaries()
 {
     Write-Host "Downloading CNI binaries"
     md $BaseDir\cni\config -ErrorAction Ignore
 
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/cni/wincni.exe -Destination $BaseDir\cni\wincni.exe
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/cni/wincni.exe" -Destination $BaseDir\cni\wincni.exe
 }
 
 function DownloadWindowsKubernetesScripts()
 {
     Write-Host "Downloading Windows Kubernetes scripts"
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/hns.psm1 -Destination $BaseDir\hns.psm1
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/InstallImages.ps1 -Destination $BaseDir\InstallImages.ps1
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/Dockerfile -Destination $BaseDir\Dockerfile
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/stop.ps1 -Destination $BaseDir\stop.ps1
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/start-kubelet.ps1 -Destination $BaseDir\start-Kubelet.ps1 
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/start-kubeproxy.ps1 -Destination $BaseDir\start-Kubeproxy.ps1
-    DownloadFile -Url  https://github.com/Microsoft/SDN/raw/master/Kubernetes/windows/AddRoutes.ps1 -Destination $BaseDir\AddRoutes.ps1
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/hns.psm1" -Destination $BaseDir\hns.psm1
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/InstallImages.ps1" -Destination $BaseDir\InstallImages.ps1
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/Dockerfile" -Destination $BaseDir\Dockerfile
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/stop.ps1" -Destination $BaseDir\stop.ps1
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/start-kubelet.ps1" -Destination $BaseDir\start-kubelet.ps1
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/start-kubeproxy.ps1" -Destination $BaseDir\start-Kubeproxy.ps1
+    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/AddRoutes.ps1" -Destination $BaseDir\AddRoutes.ps1
 }
 
 function DownloadAllFiles()
@@ -35,7 +41,7 @@ md $BaseDir -ErrorAction Ignore
 $helper = "c:\k\helper.psm1"
 if (!(Test-Path $helper))
 {
-    Start-BitsTransfer https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/helper.psm1 -Destination c:\k\helper.psm1
+    Start-BitsTransfer "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/helper.psm1" -Destination c:\k\helper.psm1
 }
 ipmo $helper
 


### PR DESCRIPTION
This patch makes it easy to use a Github fork repo instead of
https://github.com/Microsoft/SDN by setting the GITHUB_SDN_REPOSITORY
environment variable.

This allows using a fork eg while waiting for a PR to be reviewed.

Tested manually.