### PR TITLE
Fixes for Kubernetes 1.14 windows node setup

### DIFF
--- a/Kubernetes/flannel/start-kubelet.ps1
+++ b/Kubernetes/flannel/start-kubelet.ps1
@@ -28,7 +28,7 @@ if ($RegisterOnly.IsPresent)
 $kubeletArgs = @(
     "--hostname-override=$(hostname)"
     '--v=6'
-    '--pod-infra-container-image=kubeletwin/pause'
+    '--pod-infra-container-image=mcr.microsoft.com/k8s/core/pause:1.0.0'
     '--resolv-conf=""'
     '--allow-privileged=true'
     '--enable-debugging-handlers'

--- a/Kubernetes/flannel/start.ps1
+++ b/Kubernetes/flannel/start.ps1
@@ -39,7 +39,7 @@ if (!(Test-Path $install))
 }
 
 # Download files, move them, & prepare network
-powershell $install -NetworkMode $NetworkMode -clusterCIDR $ClusterCIDR -KubeDnsServiceIP $KubeDnsServiceIP -serviceCIDR $ServiceCIDR -InterfaceName $InterfaceName -LogDir $LogDir
+powershell $install -NetworkMode "$NetworkMode" -clusterCIDR "$ClusterCIDR" -KubeDnsServiceIP "$KubeDnsServiceIP" -serviceCIDR "$ServiceCIDR" -InterfaceName "'$InterfaceName'" -LogDir "$LogDir"
 
 # Register node
 powershell $BaseDir\start-kubelet.ps1 -RegisterOnly -NetworkMode $NetworkMode

--- a/Kubernetes/windows/install.ps1
+++ b/Kubernetes/windows/install.ps1
@@ -63,7 +63,6 @@ function DownloadWindowsKubernetesScripts
 {
     Write-Host "Downloading Windows Kubernetes scripts"
     DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/hns.psm1" -Destination $BaseDir\hns.psm1
-    DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/InstallImages.ps1" -Destination $BaseDir\InstallImages.ps1
     DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/windows/Dockerfile" -Destination $BaseDir\Dockerfile
     DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/stop.ps1" -Destination $BaseDir\stop.ps1
     DownloadFile -Url "https://github.com/$GithubSDNRepository/raw/master/Kubernetes/flannel/start-kubelet.ps1" -Destination $BaseDir\start-kubelet.ps1
@@ -95,9 +94,6 @@ DownloadAllFiles($NetworkMode)
 
 # Copy files into runtime directories
 CopyFiles
-
-# Prepare POD infra Images
-start powershell $BaseDir\InstallImages.ps1
 
 # Prepare Network
 ipmo C:\k\hns.psm1


### PR DESCRIPTION
I ran into two problems following the guide today:

1. `start.ps1` was throwing an error that `Argument '2' …` was not expected. This was because my Ethernet adapter was `Ethernet 2` which includes a space. The network adapter name needs to be quoted to handle spaces.
2. I was getting an OS mismatch starting pods. Moving to the published multi-version pause image fixes this and speeds up setup.