### PR TITLE
Replace non-existing pause-image name

### DIFF
--- a/Kubernetes/flannel/register-svc.ps1
+++ b/Kubernetes/flannel/register-svc.ps1
@@ -22,7 +22,7 @@ cd c:\k
 
 # register kubelet
 .\nssm.exe install $KubeletSvc C:\k\kubelet.exe
-.\nssm.exe set $KubeletSvc AppParameters --hostname-override=$Hostname --v=6 --pod-infra-container-image=kubeletwin/pause --resolv-conf="" --allow-privileged=true --enable-debugging-handlers --cluster-dns=$KubeDnsServiceIP --cluster-domain=cluster.local --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge --image-pull-progress-deadline=20m --cgroups-per-qos=false  --log-dir=$LogDir --logtostderr=false --enforce-node-allocatable="" --network-plugin=cni --cni-bin-dir=c:\k\cni --cni-conf-dir=c:\k\cni\config
+.\nssm.exe set $KubeletSvc AppParameters --hostname-override=$Hostname --v=6 --pod-infra-container-image=mcr.microsoft.com/k8s/core/pause:1.0.0 --resolv-conf="" --allow-privileged=true --enable-debugging-handlers --cluster-dns=$KubeDnsServiceIP --cluster-domain=cluster.local --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge --image-pull-progress-deadline=20m --cgroups-per-qos=false  --log-dir=$LogDir --logtostderr=false --enforce-node-allocatable="" --network-plugin=cni --cni-bin-dir=c:\k\cni --cni-conf-dir=c:\k\cni\config
 .\nssm.exe set $KubeletSvc AppDirectory C:\k
 .\nssm.exe start $KubeletSvc
 


### PR DESCRIPTION
The script refers to a image not longer hosted in the registry. Replaced imagename with the same used when running start-kubelet from start.ps1 (https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/flannel/start-kubelet.ps1)