### PR TITLE
Get-NetView: Improve error resilience

### DIFF
--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -2093,20 +2093,7 @@ function Counters {
     typeperf -f BIN -o $out -sc 10 -si 5 $counterPaths > $null
 } # Counters()
 
-function HwErrorReport {
-    [CmdletBinding()]
-    Param(
-        [parameter(Mandatory=$true)] [String] $OutDir
-    )
-
-    $dir = $OutDir
-
-    $file = "WER.txt"
-    [String []] $paths = "$env:ProgramData\Microsoft\Windows\WER"
-    ExecCopyItemsAsync -OutDir $dir -File $file -Paths $paths -Destination $dir
-} # HwErrorReport()
-
-function LogsReport {
+function SystemLogs {
     [CmdletBinding()]
     Param(
         [parameter(Mandatory=$true)] [String] $OutDir
@@ -2117,7 +2104,11 @@ function LogsReport {
     $file = "WinEVT.txt"
     [String []] $paths = "$env:SystemRoot\System32\winevt"
     ExecCopyItemsAsync -OutDir $dir -File $file -Paths $paths -Destination $dir
-} # LogsReport()
+
+    $file = "WER.txt"
+    [String []] $paths = "$env:ProgramData\Microsoft\Windows\WER"
+    ExecCopyItemsAsync -OutDir $dir -File $file -Paths $paths -Destination $dir
+} # SystemLogs()
 
 function Environment {
     [CmdletBinding()]
@@ -2151,10 +2142,9 @@ function LocalhostDetail {
     $dir = (Join-Path -Path $OutDir -ChildPath "_Localhost") # sort to top
     New-Item -ItemType directory -Path $dir | Out-Null
 
-    VMHostDetail      -OutDir $dir
+    SystemLogs        -OutDir $dir
     ServicesDrivers   -OutDir $dir
-    HwErrorReport     -OutDir $dir
-    LogsReport        -OutDir $dir
+    VMHostDetail      -OutDir $dir
 } # LocalhostDetail()
 
 function CustomModule {
@@ -2382,9 +2372,8 @@ function Get-NetView {
             Start-Thread ${function:Counters}   -Params @{OutDir=$workDir}
 
             Environment       -OutDir $workDir
-            NetworkSummary    -OutDir $workDir
-
             LocalhostDetail   -OutDir $workDir
+            NetworkSummary    -OutDir $workDir
 
             NetSetupDetail    -OutDir $workDir
             VMSwitchDetail    -OutDir $workDir

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -185,31 +185,22 @@ $ExecFunctions = {
     function ExecCommand {
         [CmdletBinding()]
         Param(
-            [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Command,
-            [parameter(Mandatory=$false)] [Switch] $Trusted
+            [parameter(Mandatory=$true)] [ValidateNotNullOrEmpty()] [String] $Command
         )
 
-        $cmdLog = $Command
+        $result, $commandOut = TestCommand -Command $Command
 
-        if ($Trusted) {
-            # Skip command validation
+        if ($result -eq [CommandStatus]::Succeeded) {
             ExecCommandText -Command $Command
-            Write-Output $(Invoke-Expression $Command)
-            $cmdLog = "[Trusted] $Command"
+            Write-Output $commandOut
+            $cmdLog = $Command
         } else {
-            $result, $commandOut = TestCommand -Command $Command
+            Write-Output "[$result]"
+            Write-Output "$Command"
+            Write-Output "$commandOut"
+            Write-Output "`n`n"
 
-            if ($result -eq [CommandStatus]::Succeeded) {
-                ExecCommandText -Command $Command
-                Write-Output $commandOut
-            } else {
-                Write-Output "[$result]"
-                Write-Output "$Command"
-                Write-Output "$commandOut"
-                Write-Output "`n`n"
-
-                $cmdLog = "[$result] $Command"
-            }
+            $cmdLog = "[$result] $Command"
         }
 
         Write-CmdLog "$cmdLog"
@@ -218,14 +209,13 @@ $ExecFunctions = {
     function ExecCommands {
         [CmdletBinding()]
         Param(
-            [parameter(Mandatory=$false)] [Switch] $Trusted,
             [parameter(Mandatory=$true)] [String] $File,
             [parameter(Mandatory=$true)] [String] $OutDir,
             [parameter(Mandatory=$true)] [String[]] $Commands
         )
 
         $out = (Join-Path -Path $OutDir -ChildPath $File)
-        $($Commands | foreach {ExecCommand -Trusted:$Trusted -Command $_}) | Out-File -Encoding ascii -Append $out
+        $($Commands | foreach {ExecCommand -Command $_}) | Out-File -Encoding ascii -Append $out
     } # ExecCommands()
 } # $ExecFunctions
 
@@ -286,10 +276,6 @@ function Write-CmdLog {
     $logColor = [ConsoleColor]::White
 
     switch -regex ($CmdLog) {
-        "\[Trusted\].*" {
-            $logColor = [ConsoleColor]::Cyan
-            break
-        }
         "\[Failed\].*" {
             $logColor = [ConsoleColor]::Yellow
             break
@@ -395,7 +381,6 @@ function Show-Threads {
 function ExecCommandsAsync {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$false)] [Switch] $Trusted,
         [parameter(Mandatory=$true)] [String] $OutDir,
         [parameter(Mandatory=$true)] [String] $File,
         [parameter(Mandatory=$true)] [String[]] $Commands
@@ -522,12 +507,12 @@ function NetIp {
     $file = "Get-NetTCPConnection.txt"
     [String []] $cmds = "Get-NetTCPConnection | Format-Table -AutoSize",
                         "Get-NetTCPConnection | Format-Table -Property * -AutoSize | Out-String -Width $columns"
-    ExecCommandsAsync -Trusted -OutDir $dir -File $file -Commands $cmds
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetTcpSetting.txt"
     [String []] $cmds = "Get-NetTcpSetting  | Format-Table -AutoSize",
                         "Get-NetTcpSetting  | Format-Table -Property * -AutoSize | Out-String -Width $columns"
-    ExecCommandsAsync -Trusted -OutDir $dir -File $file -Commands $cmds
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetTransportFilter.txt"
     [String []] $cmds = "Get-NetTransportFilter  | Format-Table -AutoSize",
@@ -915,7 +900,7 @@ function ChelsioDetailPerASIC {
     [String []] $cmds = "cxgbtool.exe $ifNameVbd hardware flash ""$dir\Hardware-BusDevice$i-flash.dmp""",
                         "cxgbtool.exe $ifNameVbd cudbg collect all ""$dir\Cudbg-Collect.dmp""",
                         "cxgbtool.exe $ifNameVbd cudbg readflash ""$dir\Cudbg-Readflash.dmp"""
-    ExecCommandsAsync -Trusted -OutDir $dir -File $file -Commands $cmds
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # ChelsioDetailPerASIC()
 
 function ChelsioDetail {
@@ -1948,8 +1933,8 @@ function ServicesDrivers {
     ExecCommands -OutDir $dir -File $file -Commands $cmds # Get-Service has concurrency issues
 
     $file = "Get-WindowsDriver.txt"
-    [String []] $cmds = "Get-WindowsDriver -Online -All" # very slow, -Trusted to skip validation
-    ExecCommandsAsync -Trusted -OutDir $dir -File $file -Commands $cmds
+    [String []] $cmds = "Get-WindowsDriver -Online -All"
+    ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-WindowsEdition.txt"
     [String []] $cmds = "Get-WindowsEdition -Online"
@@ -2037,7 +2022,7 @@ function NetshTrace {
                         "Start-NetEventSession  NetRundown",
                         "Stop-NetEventSession   NetRundown",
                         "Remove-NetEventSession NetRundown"
-    ExecCommands -Trusted -OutDir $dir -File $file -Commands $cmds
+    ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     #
     # The ETL file can be converted to text using the following command:
@@ -2046,7 +2031,7 @@ function NetshTrace {
 
     $file = "NetshDump.txt"
     [String []] $cmds = "netsh dump"
-    ExecCommands -Trusted -OutDir $dir -File $file -Commands $cmds
+    ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     $file = "NetshStatistics.txt"
     [String []] $cmds = "netsh interface ipv4 show icmpstats",
@@ -2056,7 +2041,7 @@ function NetshTrace {
                         "netsh interface ipv6 show ipstats",
                         "netsh interface ipv6 show tcpstats",
                         "netsh interface ipv6 show udpstats"
-    ExecCommands -Trusted -OutDir $dir -File $file -Commands $cmds
+    ExecCommands -OutDir $dir -File $file -Commands $cmds
 
     Write-Host "`n"
     Write-Host "Processing..."
@@ -2065,7 +2050,7 @@ function NetshTrace {
                         "netsh trace show scenarios",
                         "netsh trace show providers",
                         "netsh trace diagnose scenario=NetworkSnapshot mode=Telemetry saveSessionTrace=yes report=yes ReportFile=$dir\Snapshot.cab"
-    ExecCommands -Trusted -OutDir $dir -File $file -Commands $cmds
+    ExecCommands -OutDir $dir -File $file -Commands $cmds
 } # NetshTrace()
 
 function OneX {

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -413,7 +413,7 @@ function ExecCopyItemsAsync {
 function NetIpNic {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $NicName,
+        [parameter(Mandatory=$false)] [String] $NicName,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -510,23 +510,23 @@ function NetIp {
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetTcpSetting.txt"
-    [String []] $cmds = "Get-NetTcpSetting  | Format-Table -AutoSize",
-                        "Get-NetTcpSetting  | Format-Table -Property * -AutoSize | Out-String -Width $columns"
+    [String []] $cmds = "Get-NetTcpSetting | Format-Table -AutoSize",
+                        "Get-NetTcpSetting | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetTransportFilter.txt"
-    [String []] $cmds = "Get-NetTransportFilter  | Format-Table -AutoSize",
-                        "Get-NetTransportFilter  | Format-Table -Property * -AutoSize | Out-String -Width $columns"
+    [String []] $cmds = "Get-NetTransportFilter | Format-Table -AutoSize",
+                        "Get-NetTransportFilter | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetUDPEndpoint.txt"
-    [String []] $cmds = "Get-NetUDPEndpoint  | Format-Table -AutoSize",
-                        "Get-NetUDPEndpoint  | Format-Table -Property * -AutoSize | Out-String -Width $columns"
+    [String []] $cmds = "Get-NetUDPEndpoint | Format-Table -AutoSize",
+                        "Get-NetUDPEndpoint | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 
     $file = "Get-NetUDPSetting.txt"
-    [String []] $cmds = "Get-NetUDPSetting  | Format-Table -AutoSize",
-                        "Get-NetUDPSetting  | Format-Table -Property * -AutoSize | Out-String -Width $columns"
+    [String []] $cmds = "Get-NetUDPSetting | Format-Table -AutoSize",
+                        "Get-NetUDPSetting | Format-Table -Property * -AutoSize | Out-String -Width $columns"
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # NetIp()
 
@@ -579,7 +579,7 @@ function NetNatDetail {
 function NetAdapterWorker {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $NicName,
+        [parameter(Mandatory=$false)] [String] $NicName,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -692,7 +692,7 @@ function NetAdapterWorker {
 function NetAdapterWorkerPrepare {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $NicName,
+        [parameter(Mandatory=$false)] [String] $NicName,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -719,7 +719,7 @@ function NetAdapterWorkerPrepare {
 function LbfoWorker {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $LbfoName,
+        [parameter(Mandatory=$false)] [String] $LbfoName,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -783,7 +783,7 @@ function LbfoDetail {
 function ProtocolNicDetail {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $VMSwitchId,
+        [parameter(Mandatory=$false)] [String] $VMSwitchId,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -847,7 +847,7 @@ function NativeNicDetail {
 function ChelsioDetailPerASIC {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $NicName,
+        [parameter(Mandatory=$false)] [String] $NicName,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -906,7 +906,7 @@ function ChelsioDetailPerASIC {
 function ChelsioDetail {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $NicName,
+        [parameter(Mandatory=$false)] [String] $NicName,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -985,7 +985,7 @@ function ChelsioDetail {
 function MellanoxFirmwareInfo {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $NicName,
+        [parameter(Mandatory=$false)] [String] $NicName,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -1039,7 +1039,7 @@ function MellanoxFirmwareInfo {
 function MellanoxDetailPerNic {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $NicName,
+        [parameter(Mandatory=$false)] [String] $NicName,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -1188,7 +1188,7 @@ function MellanoxSystemDetail {
 function MellanoxDetail {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $NicName,
+        [parameter(Mandatory=$false)] [String] $NicName,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -1218,7 +1218,7 @@ function MellanoxDetail {
 function MyVendorDetail {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $NicName,
+        [parameter(Mandatory=$false)] [String] $NicName,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -1321,7 +1321,7 @@ function HostVNicWorker {
 function HostVNicDetail {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $VMSwitchId,
+        [parameter(Mandatory=$false)] [String] $VMSwitchId,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -1348,9 +1348,9 @@ function HostVNicDetail {
 function VMNetworkAdapterDetail {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $VMName,
-        [parameter(Mandatory=$true)] [String] $VMNicName,
-        [parameter(Mandatory=$true)] [String] $VMNicId,
+        [parameter(Mandatory=$false)] [String] $VMName,
+        [parameter(Mandatory=$false)] [String] $VMNicName,
+        [parameter(Mandatory=$false)] [String] $VMNicId,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -1417,7 +1417,7 @@ function VMNetworkAdapterDetail {
 function VMWorker {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $VMId,
+        [parameter(Mandatory=$false)] [String] $VMId,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -1476,7 +1476,7 @@ function VMWorker {
 function VMNetworkAdapterPerVM {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $VMSwitchId,
+        [parameter(Mandatory=$false)] [String] $VMSwitchId,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -1510,7 +1510,7 @@ function VMNetworkAdapterPerVM {
 function VMSwitchWorker {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $VMSwitchId,
+        [parameter(Mandatory=$false)] [String] $VMSwitchId,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -1544,7 +1544,7 @@ function VMSwitchWorker {
 function VfpExtensionDetail {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $VMSwitchId,
+        [parameter(Mandatory=$false)] [String] $VMSwitchId,
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -2391,11 +2391,7 @@ function Get-NetView {
         # Wait for threads to complete
         Show-Threads -Threads $threads
     } catch {
-        # Reconstruct the error for logging
-        $msg = "$($error[0].InvocationInfo.MyCommand) : $($error[0].Exception.Message)`n" +
-               "$($error[0].InvocationInfo.PositionMessage)`n" +
-               "    + CategoryInfo          : $($error[0].CategoryInfo)`n" +
-               "    + FullyQualifiedErrorId : $($error[0].FullyQualifiedErrorId)"
+        $msg = $($error[0] | Out-String)
         ExecControlError -OutDir $workDir -Function "Get-NetView" -Message $msg
 
         throw $error[0]

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -100,6 +100,23 @@ $ExecFunctions = {
     # since console color only applies to the main thread.
     Set-Alias -Name Write-CmdLog -Value Write-Host
 
+    <#
+    .SYNOPSIS
+        Log control path errors or issues.
+    #>
+    function ExecControlError {
+        [CmdletBinding()]
+        Param(
+            [parameter(Mandatory=$true)] [String] $OutDir,
+            [parameter(Mandatory=$true)] [String] $Function,
+            [parameter(Mandatory=$true)] [String] $Message
+        )
+
+        $file = "$Function.Errors.txt"
+        $out  = Join-Path $OutDir $file
+        Write-Output $Message | Out-File -Encoding ascii -Append $out
+    } # ExecControlError()
+
     function ExecCommandText {
         [CmdletBinding()]
         Param(
@@ -875,8 +892,8 @@ function ChelsioDetailPerASIC {
     }
 
     if ([String]::IsNullOrEmpty($ifNameVbd)) {
-        $out = Join-Path $dir "ChelsioDetailPerASIC-Error.txt"
-        Write-Output "Couldn't resolve interface name for bus device." | Out-File -Encoding ascii -Append $out
+        $msg =  "$NicName : Couldn't resolve interface name for bus device."
+        ExecControlError -OutDir $dir -Function "ChelsioDetailPerASIC" -Message $msg
         return
     }
 
@@ -930,8 +947,8 @@ function ChelsioDetail {
 
     # Check path for cxgbtool.exe, since it's needed to collect most Chelsio related logs.
     if (-not (Get-Command "cxgbtool.exe" -ErrorAction SilentlyContinue)) {
-        $out = Join-Path $dir "ChelsioDetail-Error.txt"
-        Write-Output "Unable to collect Chelsio debug logs as cxgbtool is not present." | Out-File -Encoding ascii -Append $out
+        $msg = "Unable to collect Chelsio debug logs as cxgbtool is not present."
+        ExecControlError -OutDir $dir -Function "ChelsioDetail" -Message $msg
         return
     }
 
@@ -953,8 +970,8 @@ function ChelsioDetail {
     }
 
     if ([String]::IsNullOrEmpty($ifNameNic)) {
-        $out = Join-Path $dir "ChelsioDetail-Error.txt"
-        Write-Output "Couldn't resolve interface name for Network device(ifIndex:$ifIndex)" | Out-File -Encoding ascii -Append $out
+        $msg = "Couldn't resolve interface name for Network device(ifIndex:$ifIndex)"
+        ExecControlError -OutDir $dir -Function "ChelsioDetail" -Message $msg
         return
     }
 
@@ -987,13 +1004,12 @@ function MellanoxFirmwareInfo {
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
-    $file = "MellanoxFirmwareInfo-Error.txt"
     $dir  = $OutDir
-    $out  = Join-Path $dir $file
 
     $mstStatus = TryCmd {mst status -v}
     if ((-not $mstStatus) -or ($mstStatus -like "*error*")) {
-        Write-Output "$NicName : MFT is not installed on this server" | Out-File -Encoding ascii -Append $out
+        $msg = "MFT is not installed on this server"
+        ExecControlError -OutDir $dir -Function "MellanoxFirmwareInfo" -Message $msg
         return
     }
 
@@ -1015,7 +1031,8 @@ function MellanoxFirmwareInfo {
     }
 
     if (-not $found) {
-        Write-Output "$NicName : No matching device found in mst status" | Out-File -Encoding ascii -Append $out
+        $msg = "No matching device found in mst status"
+        ExecControlError -OutDir $dir -Function "MellanoxFirmwareInfo" -Message $msg
         return
     }
 
@@ -1058,8 +1075,8 @@ function MellanoxDetailPerNic {
             break
         }
         default {
-            $out = Join-Path $dir "MellanoxDetailPerNic-Error.txt"
-            Write-Output "Driver $driverFileName isn't supported" | Out-File -Encoding ascii -Append $out
+            $msg = "Driver $driverFileName isn't supported"
+            ExecControlError -OutDir $dir -Function"MellanoxDetailPerNic" -Message $msg
             return
         }
     }
@@ -1199,8 +1216,8 @@ function MellanoxDetail {
     $versionMajor, $versionMinor, $_ = $driverVersionString -split "\."
 
     if (($versionMajor -lt 2) -or (($versionMajor -eq 2) -and ($versionMinor -lt 20))) {
-        $out  = Join-Path $dir "MellanoxDetail-Error.txt"
-        Write-Output "$NicName : Driver version is $versionMajor.$versionMinor, which is less than 2.20" | Out-File -Encoding ascii -Append $out
+        $msg = "Driver version is $versionMajor.$versionMinor, which is less than 2.20"
+        ExecControlError -OutDir $out -Function "MellanoxDetail" -Message $msg
         return
     }
 
@@ -2378,7 +2395,7 @@ function Get-NetView {
     )
 
     $start = Get-Date
-    $version = "2019.05.15.0" # Version within date context
+    $version = "2019.06.04.0" # Version within date context
 
     # Input Validation
     CheckAdminPrivileges $SkipAdminCheck
@@ -2393,7 +2410,6 @@ function Get-NetView {
         Open-GlobalThreadPool -MaxThreads $MaxThreads
 
         $threads = if ($true) {
-
             Start-Thread ${function:NetshTrace} -Params @{OutDir=$workDir}
             Start-Thread ${function:Counters}   -Params @{OutDir=$workDir}
 
@@ -2415,16 +2431,22 @@ function Get-NetView {
             HNSDetail         -OutDir $workDir
         }
 
-        # Show thread output, and wait for them all to complete
+        # Wait for threads to complete
         Show-Threads -Threads $threads
-
-        # Tamper Detection
-        Sanity            -OutDir $workDir -Params $PSBoundParameters
     } catch {
-        throw $error[0] # try finally obfuscates error
+        # Reconstruct the error for logging
+        $msg = "$($error[0].InvocationInfo.MyCommand) : $($error[0].Exception.Message)`n" +
+               "$($error[0].InvocationInfo.PositionMessage)`n" +
+               "    + CategoryInfo          : $($error[0].CategoryInfo)`n" +
+               "    + FullyQualifiedErrorId : $($error[0].FullyQualifiedErrorId)"
+        ExecControlError -OutDir $workDir -Function "Get-NetView" -Message $msg
+
+        throw $error[0]
     } finally {
         Close-GlobalThreadPool
+
+        Sanity -OutDir $workDir -Params $PSBoundParameters
+        Completion -Src $workDir
     }
 
-    Completion -Src $workDir
 } Get-NetView @PSBoundParameters # Entry Point

--- a/Diagnostics/Get-NetView.PS1
+++ b/Diagnostics/Get-NetView.PS1
@@ -530,7 +530,7 @@ function NetIp {
     ExecCommandsAsync -OutDir $dir -File $file -Commands $cmds
 } # NetIp()
 
-function NetNat {
+function NetNatDetail {
     [CmdletBinding()]
     Param(
         [parameter(Mandatory=$true)] [String] $OutDir
@@ -1270,7 +1270,7 @@ function NicVendor {
 function HostVNicWorker {
     [CmdletBinding()]
     Param(
-        [parameter(Mandatory=$true)] [String] $HostVNicName,
+        [parameter(Mandatory=$false)] [String] $HostVNicName, # Note: "" is a valid Host vNIC name.
         [parameter(Mandatory=$true)] [String] $OutDir
     )
 
@@ -1326,39 +1326,22 @@ function HostVNicDetail {
     )
 
     # Cache output
-    $allNetAdapters = Get-NetAdapter -IncludeHidden
+    $allNetAdapters = Get-NetAdapter
 
-    foreach ($nic in TryCmd {Get-VMNetworkAdapter -ManagementOS} | where {$_.SwitchId -eq $VMSwitchId}) {
-        <#
-            Correlate to VMNic instance to NetAdapter instance view
-            Physical to Virtual Mapping.
-            -----------------------------
-            Get-NetAdapter uses:
-               Name                    : vEthernet (VMS-Ext-Public) 2
-            Get-VMNetworkAdapter uses:
-               Name                    : VMS-Ext-Public
+    foreach ($hnic in TryCmd {Get-VMNetworkAdapter -ManagementOS} | where {$_.SwitchId -eq $VMSwitchId}) {
+        # Use device ID to find corresponding NetAdapter instance
+        $vnic = $allNetAdapters | where {$_.DeviceID -eq $hnic.DeviceID}
 
-            Thus we need to match the corresponding devices via DeviceID such that
-            we can execute VMNetworkAdapter and NetAdapter information for this hNIC
-        #>
-        $idx = 0
-        foreach($pnic in $allNetAdapters) {
-            if ($pnic.DeviceID -eq $nic.DeviceId) {
-                $pnicname = $pnic.Name
-                $idx      = $pnic.InterfaceIndex
-            }
-        }
-
-        # Create dir for each NIC
-        $name    = $nic.Name
-        $title   = "hNic.$idx.$name"
+        # Create dir for the hNIC
+        $ifIndex = $vnic.InterfaceIndex
+        $title   = "hNic.$ifIndex.$($hnic.Name)"
         $dir     = (Join-Path -Path $OutDir -ChildPath "$title")
         New-Item -ItemType directory -Path $dir | Out-Null
 
         Write-Host "Processing: $title"
-        NetIpNic         -NicName      $pnicname -OutDir $dir
-        HostVNicWorker   -HostVNicName $name     -OutDir $dir
-        NetAdapterWorker -NicName      $pnicname -OutDir $dir
+        HostVNicWorker   -HostVNicName $hnic.Name -OutDir $dir
+        NetAdapterWorker -NicName      $vnic.Name -OutDir $dir
+        NetIpNic         -NicName      $vnic.Name -OutDir $dir
     }
 } # HostVNicDetail()
 
@@ -2412,7 +2395,7 @@ function Get-NetView {
             QosDetail         -OutDir $workDir
             SMBDetail         -OutDir $workDir
             NetIp             -OutDir $workDir
-            NetNat            -OutDir $workDir
+            NetNatDetail      -OutDir $workDir
             HNSDetail         -OutDir $workDir
         }
 


### PR DESCRIPTION
1. Make sure Sanity and Completion are always executed, so a zip is created.
2. If the script crashes, the error message is collected and zipped.
3. Set parameter mandatory = $false for some parameters. This allows them to be null or empty, which should prevent or delay some crashes.
4. Remove `-Trusted` commands since there is no longer a performance benefits, and it can hide errors from the output.

#### Other Changes
1. New function ExecControlError for consistent error logging.
2. Rename NetNat to NetNatDetail.
3. Combine HwErrorReport and LogsReport into one function.
4. Slightly reorder some modules based on importance.