### PR TITLE
Windows Server 2019 Install Network Controller

### DIFF
--- a/VMM/Templates/NC/NCSetup.cr/PrepareNodeForNetworkController.ps1
+++ b/VMM/Templates/NC/NCSetup.cr/PrepareNodeForNetworkController.ps1
@@ -36,6 +36,7 @@ try
     #------------------------------------------
     Log "Installing NetworkController Role.."
     Add-WindowsFeature -Name NetworkController -IncludeManagementTools
+    Add-WindowsFeature RSAT-AD-PowerShell
 
     #------------------------------------------
     # Add the domain account as local admin on this machine


### PR DESCRIPTION
Windows 2019 Core installing networking controller service doesn't have `Get-ADGroup` from RAST-AD_Powershell included by default.

```
Error (22631)
The script command exit code 2148734209 matched the failure policy setting "Match any value other than zero." Standard output log data: "[2019-07-10T13:53:42.1854232+07:00]Validating Management security group..
[2019-07-10T13:53:43.5742152+07:00]Caught an exception:
[2019-07-10T13:53:43.5742152+07:00]    Exception Type: System.Management.Automation.CommandNotFoundException
[2019-07-10T13:53:43.5742152+07:00]    Exception Message: The term 'Get-ADGroup' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
[2019-07-10T13:53:43.5742152+07:00]    Exception HResult: -2146233087"

Recommended Action
If the script command's job restart action is set to restart, then the script will be re-executed. Otherwise, the script command will be skipped when the job is restarted, in which case corrective action should be taken to mitigate the effects of the script command failure.
```

Platform:
- Windows Server 2019 Data Center
- System Center Virtual Machine Manager 2019