### PR TITLE
Only using the kubelet flag `allow-privileged` for versions < 1.15

### DIFF
--- a/Kubernetes/flannel/register-svc.ps1
+++ b/Kubernetes/flannel/register-svc.ps1
@@ -9,6 +9,19 @@ Param(
     [parameter(Mandatory = $false)] $FlanneldSvc="flanneld"
 )
 
+$GithubSDNRepository = 'Microsoft/SDN'
+if ((Test-Path env:GITHUB_SDN_REPOSITORY) -and ($env:GITHUB_SDN_REPOSITORY -ne ''))
+{
+    $GithubSDNRepository = $env:GITHUB_SDN_REPOSITORY
+}
+
+$helper = 'c:\k\helper.psm1'
+if (!(Test-Path $helper))
+{
+    Start-BitsTransfer "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/helper.psm1" -Destination c:\k\helper.psm1
+}
+ipmo $helper
+
 $Hostname=$(hostname).ToLower()
 $NetworkMode = $NetworkMode.ToLower()
 cd c:\k
@@ -22,7 +35,13 @@ cd c:\k
 
 # register kubelet
 .\nssm.exe install $KubeletSvc C:\k\kubelet.exe
-.\nssm.exe set $KubeletSvc AppParameters --hostname-override=$Hostname --v=6 --pod-infra-container-image=kubeletwin/pause --resolv-conf="" --allow-privileged=true --enable-debugging-handlers --cluster-dns=$KubeDnsServiceIP --cluster-domain=cluster.local --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge --image-pull-progress-deadline=20m --cgroups-per-qos=false  --log-dir=$LogDir --logtostderr=false --enforce-node-allocatable="" --network-plugin=cni --cni-bin-dir=c:\k\cni --cni-conf-dir=c:\k\cni\config
+$kubeletOptions = Kubelet-Options $KubeDnsServiceIp $LogDir
+$nssmArgs = @(
+    'set'
+    $KubeletSvc
+    'AppParameters'
+) + $kubeletOptions.Options
+& .\nssm.exe $nssmArgs
 .\nssm.exe set $KubeletSvc AppDirectory C:\k
 .\nssm.exe start $KubeletSvc
 

--- a/Kubernetes/flannel/start-kubelet.ps1
+++ b/Kubernetes/flannel/start-kubelet.ps1
@@ -30,7 +30,6 @@ $kubeletArgs = @(
     '--v=6'
     '--pod-infra-container-image=mcr.microsoft.com/k8s/core/pause:1.0.0'
     '--resolv-conf=""'
-    '--allow-privileged=true'
     '--enable-debugging-handlers'
     "--cluster-dns=$KubeDnsServiceIp"
     '--cluster-domain=cluster.local'
@@ -46,6 +45,22 @@ $kubeletArgs = @(
     '--cni-conf-dir="c:\k\cni\config"'
     "--node-ip=$(Get-MgmtIpAddress)"
 )
+
+if (($kubeletVersionOutput = c:\k\kubelet.exe --version) -and $kubeletVersionOutput -match '^(?:kubernetes )?v?([0-9]+(?:\.[0-9]+){1,2})')
+{
+    $kubeletVersion = [System.Version]$matches[1]
+    Write-Host "Detected kubelet version $kubeletVersion"
+
+    if ($kubeletVersion -lt [System.Version]'1.15')
+    {
+        # this flag got deprecated in version 1.15
+        $kubeletArgs += '--allow-privileged=true'
+    }
+}
+else
+{
+    Write-Host 'Unable to determine kubelet version'
+}
 
 if ($KubeletFeatureGates -ne "")
 {

--- a/Kubernetes/flannel/start-kubelet.ps1
+++ b/Kubernetes/flannel/start-kubelet.ps1
@@ -12,7 +12,7 @@ if ((Test-Path env:GITHUB_SDN_REPOSITORY) -and ($env:GITHUB_SDN_REPOSITORY -ne '
     $GithubSDNRepository = $env:GITHUB_SDN_REPOSITORY
 }
 
-$helper = "c:\k\helper.psm1"
+$helper = 'c:\k\helper.psm1'
 if (!(Test-Path $helper))
 {
     Start-BitsTransfer "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/helper.psm1" -Destination c:\k\helper.psm1
@@ -25,46 +25,10 @@ if ($RegisterOnly.IsPresent)
     exit
 }
 
-$kubeletArgs = @(
-    "--hostname-override=$(hostname)"
-    '--v=6'
-    '--pod-infra-container-image=mcr.microsoft.com/k8s/core/pause:1.0.0'
-    '--resolv-conf=""'
-    '--enable-debugging-handlers'
-    "--cluster-dns=$KubeDnsServiceIp"
-    '--cluster-domain=cluster.local'
-    '--kubeconfig=c:\k\config'
-    '--hairpin-mode=promiscuous-bridge'
-    '--image-pull-progress-deadline=20m'
-    '--cgroups-per-qos=false'
-    "--log-dir=$LogDir"
-    '--logtostderr=false'
-    '--enforce-node-allocatable=""'
-    '--network-plugin=cni'
-    '--cni-bin-dir="c:\k\cni"'
-    '--cni-conf-dir="c:\k\cni\config"'
-    "--node-ip=$(Get-MgmtIpAddress)"
-)
-
-if (($kubeletVersionOutput = c:\k\kubelet.exe --version) -and $kubeletVersionOutput -match '^(?:kubernetes )?v?([0-9]+(?:\.[0-9]+){1,2})')
-{
-    $kubeletVersion = [System.Version]$matches[1]
-    Write-Host "Detected kubelet version $kubeletVersion"
-
-    if ($kubeletVersion -lt [System.Version]'1.15')
-    {
-        # this flag got deprecated in version 1.15
-        $kubeletArgs += '--allow-privileged=true'
-    }
-}
-else
-{
-    Write-Host 'Unable to determine kubelet version'
-}
-
+$kubeletOptions = Kubelet-Options $KubeDnsServiceIp $LogDir
 if ($KubeletFeatureGates -ne "")
 {
-    $kubeletArgs += "--feature-gates=$KubeletFeatureGates"
+    $kubeletOptions.Options += "--feature-gates=$KubeletFeatureGates"
 }
 
-& c:\k\kubelet.exe $kubeletArgs
+& c:\k\kubelet.exe $kubeletOptions.Options

--- a/Kubernetes/windows/start-kubelet.ps1
+++ b/Kubernetes/windows/start-kubelet.ps1
@@ -112,26 +112,10 @@ netsh int ipv4 set int "$vnicName" for=en
 #netsh int ipv4 set add "vEthernet (cbr0)" static $podGW 255.255.255.0
 Update-CNIConfig $podCIDR
 
-if ($IsolationType -ieq "process")
+$kubeletOptions = Kubelet-Options $KubeDnsServiceIp
+if ($IsolationType -ieq 'hyperv')
 {
-    c:\k\kubelet.exe --hostname-override=$(hostname) --v=6 `
-        --pod-infra-container-image=kubeletwin/pause --resolv-conf="" `
-        --allow-privileged=true --enable-debugging-handlers `
-        --cluster-dns=$KubeDnsServiceIp --cluster-domain=cluster.local `
-        --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge `
-        --image-pull-progress-deadline=20m --cgroups-per-qos=false `
-        --log-dir=c:\k --logtostderr=false --enforce-node-allocatable="" `
-        --network-plugin=cni --cni-bin-dir="c:\k\cni" --cni-conf-dir "c:\k\cni\config"
+    $kubeletOptions.Options += '--feature-gates=HyperVContainer=true'
 }
-elseif ($IsolationType -ieq "hyperv")
-{
-    c:\k\kubelet.exe --hostname-override=$(hostname) --v=6 `
-        --pod-infra-container-image=kubeletwin/pause --resolv-conf="" `
-        --allow-privileged=true --enable-debugging-handlers `
-        --cluster-dns=$KubeDnsServiceIp --cluster-domain=cluster.local `
-        --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge `
-        --image-pull-progress-deadline=20m --cgroups-per-qos=false `
-        --feature-gates=HyperVContainer=true --enforce-node-allocatable="" `
-        --log-dir=c:\k --logtostderr=false `
-        --network-plugin=cni --cni-bin-dir="c:\k\cni" --cni-conf-dir "c:\k\cni\config"
-}
+
+& c:\k\kubelet.exe $kubeletOptions.Options


### PR DESCRIPTION
Since that flag got deprecated in version 1.15, and the kubelet won't
start if it's present.

Fixes https://github.com/microsoft/SDN/issues/379