### PR TITLE
Remove invalid setting for 1.15

### DIFF
--- a/Kubernetes/flannel/start-kubelet.ps1
+++ b/Kubernetes/flannel/start-kubelet.ps1
@@ -30,7 +30,6 @@ $kubeletArgs = @(
     '--v=6'
     '--pod-infra-container-image=mcr.microsoft.com/k8s/core/pause:1.0.0'
     '--resolv-conf=""'
-    '--allow-privileged=true'
     '--enable-debugging-handlers'
     "--cluster-dns=$KubeDnsServiceIp"
     '--cluster-domain=cluster.local'


### PR DESCRIPTION
`allow-privileged` causes the kubelet to fail in 1.15. Remove this and the script works correctly - there are still various other deprecated settings which throw warnings, but this is the only one which stops the kubelet running.