### PR TITLE
Support kubelet 1.15 on Windows

### DIFF
--- a/Kubernetes/windows/start-kubelet.ps1
+++ b/Kubernetes/windows/start-kubelet.ps1
@@ -116,7 +116,7 @@ if ($IsolationType -ieq "process")
 {
     c:\k\kubelet.exe --hostname-override=$(hostname) --v=6 `
         --pod-infra-container-image=kubeletwin/pause --resolv-conf="" `
-        --allow-privileged=true --enable-debugging-handlers `
+        --enable-debugging-handlers `
         --cluster-dns=$KubeDnsServiceIp --cluster-domain=cluster.local `
         --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge `
         --image-pull-progress-deadline=20m --cgroups-per-qos=false `
@@ -127,7 +127,7 @@ elseif ($IsolationType -ieq "hyperv")
 {
     c:\k\kubelet.exe --hostname-override=$(hostname) --v=6 `
         --pod-infra-container-image=kubeletwin/pause --resolv-conf="" `
-        --allow-privileged=true --enable-debugging-handlers `
+        --enable-debugging-handlers `
         --cluster-dns=$KubeDnsServiceIp --cluster-domain=cluster.local `
         --kubeconfig=c:\k\config --hairpin-mode=promiscuous-bridge `
         --image-pull-progress-deadline=20m --cgroups-per-qos=false `


### PR DESCRIPTION
Starting with version 1.15 the --allow-privileged switch has been [deprecated](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md#node) in kubelet. Because of this `kubelet.exe` is not started when running the script referenced in the [Kubernetes Windows Guide](https://kubernetes.io/docs/setup/production-environment/windows/user-guide-windows-nodes/#join-the-windows-node-to-the-flannel-cluster).