### PR TITLE
Fix/kubecluster 1.15 deprecated args

### DIFF
--- a/Kubernetes/windows/helper.v2.psm1
+++ b/Kubernetes/windows/helper.v2.psm1
@@ -777,7 +777,6 @@ function GetKubeletArguments()
         '--v=6',
         '--pod-infra-container-image=kubeletwin/pause',
         '--resolv-conf=""',
-        '--allow-privileged=true',
         '--enable-debugging-handlers', # Comment for Config
         "--cluster-dns=$KubeDnsServiceIp", # Comment for Config
         '--cluster-domain=cluster.local', # Comment for Config
@@ -793,6 +792,22 @@ function GetKubeletArguments()
         "--cni-conf-dir=$CniConf",
         "--node-ip=$NodeIp"
     )
+
+    if (($kubeletVersionOutput = C:\k\kubernetes\node\bin\kubelet.exe --version) -and $kubeletVersionOutput -match '^(?:kubernetes )?v?([0-9]+(?:\.[0-9]+){1,2})')
+    {
+        $kubeletVersion = [System.Version]$matches[1]
+        Write-Host "Detected kubelet version $kubeletVersion"
+
+        if ($kubeletVersion -lt [System.Version]'1.15')
+        {
+            # this flag got deprecated in version 1.15
+            $kubeletArgs += '--allow-privileged=true'
+        }
+    }
+    else
+    {
+        Write-Host 'Unable to determine kubelet version'
+    }
 
     if ($KubeletFeatureGates -ne "")
     {

--- a/Kubernetes/windows/kubeadm/Kubecluster.md
+++ b/Kubernetes/windows/kubeadm/Kubecluster.md
@@ -26,10 +26,12 @@ Min. Windows Operating System Version : 1809 (Tested).
             "InterfaceName" : "Ethernet"
         },
         "Kubernetes" : {
-            "Release" : "1.14.0",
             "Master" : {
                 "IpAddress" : "<NameOrIpOfMaster>",
                 "Username" : "<UserNameOfUseronMaster>"
+            },
+            "Source": {
+                "Release": "1.15.2"
             }
         },
         "Install" : {


### PR DESCRIPTION
Since 1.15, kubelet binary doesn't access `--allow-privileged` flag anymore. So the kubelet service will be crashed and the windows nodes wouldn't be able to connect to the cluster.
This PR fixes the above issue with kubernetes >= 1.15
