### PR TITLE
Pass Release parameter in to InstallKubernetes function

### DIFF
--- a/Kubernetes/linux/kubeadm/kubecluster.sh
+++ b/Kubernetes/linux/kubeadm/kubecluster.sh
@@ -42,7 +42,7 @@ function InstallKubernetes()
 	cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
 	deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
-	apt-get update && apt-get install -y kubelet kubeadm kubectl 
+	apt-get update && apt-get install -y kubelet=$1* kubeadm=$1* kubectl=$1*
 }
 
 function DownloadKubernetes()
@@ -263,7 +263,7 @@ echo "++++++++++++++++++++++++++++++++++++++++++++++++++"
 # Pre-Requisites
 InstallPreReq
 DownloadKubernetes $WorkingDir $Release
-InstallKubernetes
+InstallKubernetes $Release
 # Kubeadm pre-requisites
 # Turn off Swap
 sudo swapoff -a 


### PR DESCRIPTION
Currently kubecluster.sh doesn't actually respect the release specified when picking K8S packages to install from APT.  This PR filters the makes it select from only packages matching the supplied release string.