### PR TITLE
Fix LastExitCode checks in helper.v2.ps1

### DIFF
--- a/Kubernetes/windows/helper.v2.psm1
+++ b/Kubernetes/windows/helper.v2.psm1
@@ -1544,7 +1544,7 @@ function InstallDockerImages()
     if (!(docker images $Global:NanoserverImage -q))
     {
         docker pull $Global:NanoserverImage
-        if (!$LastExitCode) {
+        if (!($LastExitCode -eq 0)) {
             throw "Failed to pull $Global:NanoserverImage"
         }
     }
@@ -1552,7 +1552,7 @@ function InstallDockerImages()
     if (!(docker images $Global:ServercoreImage -q))
     {
         docker pull $Global:ServercoreImage
-        if (!$LastExitCode) {
+        if (!($LastExitCode -eq 0)) {
             throw "Failed to pull $Global:ServercoreImage"
         }
     }

--- a/Kubernetes/windows/kubeadm/Kubecluster.md
+++ b/Kubernetes/windows/kubeadm/Kubecluster.md
@@ -50,9 +50,9 @@ Min. Windows Operating System Version : 1809 (Tested).
     d. Usage
     ```
         cd  $env:HOMEDRIVE\$env:HOMEPATH
-        wget  https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/KubeCluster.ps1 -o kubecluster.ps1
+        wget  https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/kubeadm/KubeCluster.ps1 -o KubeCluster.ps1
 
-        .\KubeCluster.ps1 -InstallPrerequisite -Config .\KubeCluster.json
+        .\KubeCluster.ps1 -InstallPrerequisite -ConfigFile .\KubeCluster.json
     ```
         <The machine might need to be rebooted, if containers role was installed. If not, you can say no>
 
@@ -72,21 +72,21 @@ Min. Windows Operating System Version : 1809 (Tested).
 
 ### Flannel VxLan
     ```
-   	wget  https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/kubeadm/Kubecluster.json -o kubecluster.json
+   	wget  https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/kubeadm/Kubeclustervxlan.json -o kubecluster.json
     # Modify the required params
-	.\KubeCluster.ps1 -join -Config .\KubeCluster.json
+	.\KubeCluster.ps1 -join -ConfigFile .\KubeCluster.json
     ```
 ### Flannel Bridge
     # Or input the file directly to the script to deploy the configuration in json
     ```
-	.\KubeCluster.ps1 -join -Config  https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/kubeadm/Kubecluster.json
+	.\KubeCluster.ps1 -join -ConfigFile  https://raw.githubusercontent.com/Microsoft/SDN/master/Kubernetes/windows/kubeadm/Kubeclusterbridge.json
 
     ```
 ## Reset the node
     This option would undo whatever join did to the node & removes the node from the Kubernetes cluster.
     ```
     
-    .\KubeCluster.ps1 -reset -Config .\KubeCluster.json
+    .\KubeCluster.ps1 -reset -ConfigFile .\KubeCluster.json
     ```
 
 ## Sample Output


### PR DESCRIPTION
Currently when installing the base docker images, after a *successful* pull the $LastExitCode check will fail:

```1809: Pulling from windows/nanoserver
85bcf813f547: Pull complete
Digest: sha256:26023bec87a34fc1ce9e2241968de68b985ba9394d5458a5d2a83b6a8be4349e
Status: Downloaded newer image for mcr.microsoft.com/windows/nanoserver:1809
mcr.microsoft.com/windows/nanoserver:1809
Failed to pull mcr.microsoft.com/windows/nanoserver:1809
At C:\Users\vmadmin\AppData\Local\Temp\1\helper.v2.psm1:1548 char:13
+             throw "Failed to pull $Global:NanoserverImage"
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Failed to pull ...nanoserver:1809:String) [], RuntimeException
    + FullyQualifiedErrorId : Failed to pull mcr.microsoft.com/windows/nanoserver:1809```

Also updated some stale parameter names in the documentation (referenced -Config instead of -ConfigFile) and an incorrect path