### PR TITLE
Improving the collect logs to show the number of available ephemeral ports and the hns network layer info

### DIFF
--- a/Kubernetes/windows/debug/collectlogs.ps1
+++ b/Kubernetes/windows/debug/collectlogs.ps1
@@ -65,5 +65,21 @@ if ($res)
     docker ps -a > docker.txt
 }
 
+netsh int ipv4 sh excludedportrange TCP > reservedports.txt
+netsh int ipv4 sh excludedportrange UDP >> reservedports.txt
+
+$ver = [System.Environment]::OSVersion
+$hotFix = Get-HotFix
+
+$ver.ToString() > winver.txt
+"`n`n" >> winver.txt
+
+if ($hotFix -ne $null)
+{
+    $hotFix >> winver.txt
+} else {
+    "<No hotfix>" >> winver.txt
+}
+
 popd
 Write-Host "Logs are available at $outDir"

--- a/Kubernetes/windows/debug/collectlogs.ps1
+++ b/Kubernetes/windows/debug/collectlogs.ps1
@@ -34,7 +34,7 @@ pushd
 cd $outDir
 
 Get-HnsNetwork | Select Name, Type, Id, AddressPrefix > network.txt
-Get-hnsnetwork | Convertto-json -Depth 20 >> network.txt
+Get-hnsnetwork | % { Get-HnsNetwork -Id $_.ID -Detailed } | Convertto-json -Depth 20 >> network.txt
 
 Get-HnsEndpoint | Select IpAddress, MacAddress, IsRemoteEndpoint, State > endpoint.txt
 Get-hnsendpoint | Convertto-json -Depth 20 >> endpoint.txt
@@ -65,8 +65,53 @@ if ($res)
     docker ps -a > docker.txt
 }
 
-netsh int ipv4 sh excludedportrange TCP > reservedports.txt
+function CountAvailableEphemeralPorts([string]$portocol = "TCP", [uint32]$portRangeSize = 64) {
+    # First, remove all the text bells and whistle (plain text, table headers, dashes, empty lines, ...) from netsh output 
+    $tcpRanges = (netsh int ipv4 sh excludedportrange $portocol) -replace "[^0-9,\ ]",'' | ? {$_.trim() -ne "" }
+ 
+    # Then, remove any extra space characters. Only capture the numbers representing the beginning and end of range
+    $tcpRangesArray = $tcpRanges -replace "\s+(\d+)\s+(\d+)\s+",'$1,$2' | ConvertFrom-String -Delimiter ","
+
+    # Extract the ephemeral ports ranges
+    $EphemeralPortRange = (netsh int ipv4 sh dynamicportrange $portocol) -replace "[^0-9]",'' | ? {$_.trim() -ne "" }
+    $EphemeralPortStart = [Convert]::ToUInt32($EphemeralPortRange[0])
+    $EphemeralPortEnd = $EphemeralPortStart + [Convert]::ToUInt32($EphemeralPortRange[1]) - 1
+
+    # Remove the non-ephemeral port reservations from the list
+    $filteredTcpRangeArray = $tcpRangesArray | ? { $_.P1 -ge $EphemeralPortStart }
+    $filteredTcpRangeArray = $filteredTcpRangeArray | ? { $_.P2 -le $EphemeralPortEnd }
+
+    $freeRanges = @()
+    # The first free range goes from $EphemeralPortStart to the beginning of the first reserved range
+    $freeRanges += ([Convert]::ToUInt32($filteredTcpRangeArray[0].P1) - $EphemeralPortStart)
+
+    for ($i = 1; $i -lt $filteredTcpRangeArray.length; $i++) {
+        # Subsequent free ranges go from the end of the previous reserved range to the beginning of the current reserved range
+        $freeRanges += ([Convert]::ToUInt32($filteredTcpRangeArray[$i].P1) - [Convert]::ToUInt32($filteredTcpRangeArray[$i-1].P2) - 1)
+    }
+
+    # The last free range goes from the end of the last reserved range to $EphemeralPortEnd
+    $freeRanges += ($EphemeralPortEnd - [Convert]::ToUInt32($filteredTcpRangeArray[$filteredTcpRangeArray.length - 1].P2) - 1)
+    
+    # Count the number of available free ranges
+    [uint32]$freeRangesCount = 0
+    ($freeRanges | % { $freeRangesCount += [UInt32]($_ / $portRangeSize) } )
+
+    return $freeRangesCount
+}
+
+$availableRangesFor64PortChunks = CountAvailableEphemeralPorts
+
+if ($availableRangesFor64PortChunks -le 0) {
+    echo "ERROR: Running out of ephemeral ports. The ephemeral ports range doesn't have enough resources to allow allocating 64 contiguous TCP ports." > reservedports.txt
+} else {
+    echo "The ephemeral port range still has room for making up to $availableRangesFor64PortChunks allocations of 64 contiguous TCP ports" > reservedports.txt
+}
+
+netsh int ipv4 sh excludedportrange TCP >> reservedports.txt
 netsh int ipv4 sh excludedportrange UDP >> reservedports.txt
+netsh int ipv4 sh dynamicportrange TCP >> reservedports.txt
+netsh int ipv4 sh dynamicportrange UDP >> reservedports.txt
 
 $ver = [System.Environment]::OSVersion
 $hotFix = Get-HotFix

--- a/Kubernetes/windows/debug/collectlogs.ps1
+++ b/Kubernetes/windows/debug/collectlogs.ps1
@@ -34,7 +34,8 @@ pushd
 cd $outDir
 
 Get-HnsNetwork | Select Name, Type, Id, AddressPrefix > network.txt
-Get-hnsnetwork | % { Get-HnsNetwork -Id $_.ID -Detailed } | Convertto-json -Depth 20 >> network.txt
+Get-hnsnetwork | Convertto-json -Depth 20 >> network.txt
+Get-hnsnetwork | % { Get-HnsNetwork -Id $_.ID -Detailed } | Convertto-json -Depth 20 >> networkdetailed.txt
 
 Get-HnsEndpoint | Select IpAddress, MacAddress, IsRemoteEndpoint, State > endpoint.txt
 Get-hnsendpoint | Convertto-json -Depth 20 >> endpoint.txt
@@ -108,10 +109,10 @@ if ($availableRangesFor64PortChunks -le 0) {
     echo "The ephemeral port range still has room for making up to $availableRangesFor64PortChunks allocations of 64 contiguous TCP ports" > reservedports.txt
 }
 
-netsh int ipv4 sh excludedportrange TCP >> reservedports.txt
-netsh int ipv4 sh excludedportrange UDP >> reservedports.txt
-netsh int ipv4 sh dynamicportrange TCP >> reservedports.txt
-netsh int ipv4 sh dynamicportrange UDP >> reservedports.txt
+netsh int ipv4 sh excludedportrange TCP > excludedportrange.txt
+netsh int ipv4 sh excludedportrange UDP >> excludedportrange.txt
+netsh int ipv4 sh dynamicportrange TCP > dynamicportrange.txt
+netsh int ipv4 sh dynamicportrange UDP >> dynamicportrange.txt
 
 
 $ver = [System.Environment]::OSVersion


### PR DESCRIPTION
Improving the collect logs to show the number of available ephemeral ports and the hns network layer info
- Added a function to count the available port ranges which have room for allocating 64 ports chunks
- Improved the Get-HNSNetwork logic to show detailed information

Tested:
- Ran the script on a server SKU computer and verified the information was accurate.