### PR TITLE
Improving the host port calculation to include used (non reserved) po…

### DIFF
--- a/Kubernetes/windows/debug/collectlogs.ps1
+++ b/Kubernetes/windows/debug/collectlogs.ps1
@@ -78,21 +78,37 @@ function CountAvailableEphemeralPorts([string]$portocol = "TCP", [uint32]$portRa
     $EphemeralPortStart = [Convert]::ToUInt32($EphemeralPortRange[0])
     $EphemeralPortEnd = $EphemeralPortStart + [Convert]::ToUInt32($EphemeralPortRange[1]) - 1
 
+     # Find the external interface
+     $externalInterfaceIdx = (Get-NetRoute -DestinationPrefix "0.0.0.0/0")[0].InterfaceIndex
+     $hostIP = (Get-NetIPConfiguration -ifIndex $externalInterfaceIdx).IPv4Address.IPAddress
+
+     # Extract the used TCP ports from the external interface
+     $usedTcpPorts = (Get-NetTCPConnection -LocalAddress $hostIP).LocalPort
+     $usedTcpPorts | % { $tcpRangesArray += [pscustomobject]@{P1 = $_; P2 = $_} }
+     $tcpRangesArray = ($tcpRangesArray | Sort-Object { $_.P1 })
+
     # Remove the non-ephemeral port reservations from the list
     $filteredTcpRangeArray = $tcpRangesArray | ? { $_.P1 -ge $EphemeralPortStart }
     $filteredTcpRangeArray = $filteredTcpRangeArray | ? { $_.P2 -le $EphemeralPortEnd }
-
-    $freeRanges = @()
-    # The first free range goes from $EphemeralPortStart to the beginning of the first reserved range
-    $freeRanges += ([Convert]::ToUInt32($filteredTcpRangeArray[0].P1) - $EphemeralPortStart)
-
-    for ($i = 1; $i -lt $filteredTcpRangeArray.length; $i++) {
-        # Subsequent free ranges go from the end of the previous reserved range to the beginning of the current reserved range
-        $freeRanges += ([Convert]::ToUInt32($filteredTcpRangeArray[$i].P1) - [Convert]::ToUInt32($filteredTcpRangeArray[$i-1].P2) - 1)
+    
+    if ($filteredTcpRangeArray -eq $null)
+    {
+        $freeRanges = @($EphemeralPortRange[1])
     }
+    else
+    {
+        $freeRanges = @()
+        # The first free range goes from $EphemeralPortStart to the beginning of the first reserved range
+        $freeRanges += ([Convert]::ToUInt32($filteredTcpRangeArray[0].P1) - $EphemeralPortStart)
 
-    # The last free range goes from the end of the last reserved range to $EphemeralPortEnd
-    $freeRanges += ($EphemeralPortEnd - [Convert]::ToUInt32($filteredTcpRangeArray[$filteredTcpRangeArray.length - 1].P2) - 1)
+        for ($i = 1; $i -lt $filteredTcpRangeArray.length; $i++) {
+            # Subsequent free ranges go from the end of the previous reserved range to the beginning of the current reserved range
+            $freeRanges += ([Convert]::ToUInt32($filteredTcpRangeArray[$i].P1) - [Convert]::ToUInt32($filteredTcpRangeArray[$i-1].P2) - 1)
+        }
+
+        # The last free range goes from the end of the last reserved range to $EphemeralPortEnd
+        $freeRanges += ($EphemeralPortEnd - [Convert]::ToUInt32($filteredTcpRangeArray[$filteredTcpRangeArray.length - 1].P2) - 1)
+    }
     
     # Count the number of available free ranges
     [uint32]$freeRangesCount = 0


### PR DESCRIPTION
Improving the host port calculation to include used (non reserved) ports and a boundary check for machine with all ports available

Tests run: manually ran the script on a Windows node