### PR TITLE
Tagging provided servercore docker image as 1809

### DIFF
--- a/Kubernetes/windows/helper.v2.psm1
+++ b/Kubernetes/windows/helper.v2.psm1
@@ -1562,6 +1562,7 @@ function InstallDockerImages()
         }
     }
     docker tag $Global:ServercoreImage mcr.microsoft.com/windows/servercore:latest
+    docker tag $Global:ServercoreImage mcr.microsoft.com/windows/servercore:1809
 }
 
 function InstallPauseImage()


### PR DESCRIPTION
This allows internal builds/container images to work with yaml files that are meant for 1809 images.
@madhanrm 