### PR TITLE
Explicitly specify supported docker version, auto-confirm installations

### DIFF
--- a/Kubernetes/linux/kubeadm/kubecluster.sh
+++ b/Kubernetes/linux/kubeadm/kubecluster.sh
@@ -33,7 +33,7 @@ USAGE
 
 function InstallPreReq()
 {
-	sudo apt install bridge-utils
+	sudo apt-get install -y bridge-utils
 }
 
 function InstallKubernetes()
@@ -87,7 +87,7 @@ function InstallRuntime()
 		# Install Docker CE
 		## Set up the repository:
 		### Install packages to allow apt to use a repository over HTTPS
-		apt-get update && apt-get install apt-transport-https ca-certificates curl software-properties-common
+		apt-get update && apt-get install -y apt-transport-https ca-certificates curl software-properties-common
 
 		### Add Docker’s official GPG key
 		curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
@@ -99,7 +99,7 @@ function InstallRuntime()
 		stable"
 
 		## Install Docker CE.
-		apt-get update && apt-get install docker-ce #=18.06.2~ce~3-0~ubuntu
+		apt-get update && apt-get install -y docker-ce=18.06* #=18.06.2~ce~3-0~ubuntu
 
 		# Setup daemon.
 		cat > /etc/docker/daemon.json <<EOF
@@ -305,5 +305,3 @@ else
 
   CleanupNetworking
 fi
-
-


### PR DESCRIPTION
Sets the script to pull a known-supported version of docker explicitly, so kubeadm preflight checks don't complain about unsupported docker versions.  Also adds auto-confirmation of installations to some apt-get commands that were missing them (making all apt-get calls consistent).