### PR TITLE
Adding a tool to collectlogs.ps1 to further detect port allocation issues

### DIFF
--- a/Kubernetes/windows/debug/collectlogs.ps1
+++ b/Kubernetes/windows/debug/collectlogs.ps1
@@ -23,6 +23,7 @@ DownloadFile -Url "https://raw.githubusercontent.com/$GithubSDNRepository/master
 DownloadFile -Url "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/debug/starthnstrace.cmd" -Destination $BaseDir\starthnstrace.cmd
 DownloadFile -Url "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/debug/startpacketcapture.cmd" -Destination $BaseDir\startpacketcapture.cmd
 DownloadFile -Url  "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/debug/stoppacketcapture.cmd" -Destination $BaseDir\stoppacketcapture.cmd
+DownloadFile -Url  "https://raw.githubusercontent.com/$GithubSDNRepository/master/Kubernetes/windows/debug/portReservationTest.ps1" -Destination $BaseDir\portReservationTest.ps1
 
 ipmo $BaseDir\hns.psm1
 
@@ -66,37 +67,51 @@ if ($res)
     docker ps -a > docker.txt
 }
 
-function CountAvailableEphemeralPorts([string]$portocol = "TCP", [uint32]$portRangeSize = 64) {
+function CountAvailableEphemeralPorts([string]$protocol = "TCP", [uint32]$portRangeSize = 64) {
     # First, remove all the text bells and whistle (plain text, table headers, dashes, empty lines, ...) from netsh output 
-    $tcpRanges = (netsh int ipv4 sh excludedportrange $portocol) -replace "[^0-9,\ ]",'' | ? {$_.trim() -ne "" }
+    $tcpRanges = (netsh int ipv4 sh excludedportrange $protocol) -replace "[^0-9,\ ]",'' | ? {$_.trim() -ne "" }
  
     # Then, remove any extra space characters. Only capture the numbers representing the beginning and end of range
     $tcpRangesArray = $tcpRanges -replace "\s+(\d+)\s+(\d+)\s+",'$1,$2' | ConvertFrom-String -Delimiter ","
 
     # Extract the ephemeral ports ranges
-    $EphemeralPortRange = (netsh int ipv4 sh dynamicportrange $portocol) -replace "[^0-9]",'' | ? {$_.trim() -ne "" }
+    $EphemeralPortRange = (netsh int ipv4 sh dynamicportrange $protocol) -replace "[^0-9]",'' | ? {$_.trim() -ne "" }
     $EphemeralPortStart = [Convert]::ToUInt32($EphemeralPortRange[0])
     $EphemeralPortEnd = $EphemeralPortStart + [Convert]::ToUInt32($EphemeralPortRange[1]) - 1
 
-     # Find the external interface
-     $externalInterfaceIdx = (Get-NetRoute -DestinationPrefix "0.0.0.0/0")[0].InterfaceIndex
-     $hostIP = (Get-NetIPConfiguration -ifIndex $externalInterfaceIdx).IPv4Address.IPAddress
+    # Find the external interface
+    $externalInterfaceIdx = (Get-NetRoute -DestinationPrefix "0.0.0.0/0")[0].InterfaceIndex
+    $hostIP = (Get-NetIPConfiguration -ifIndex $externalInterfaceIdx).IPv4Address.IPAddress
 
-     # Extract the used TCP ports from the external interface
-     $usedTcpPorts = (Get-NetTCPConnection -LocalAddress $hostIP).LocalPort
-     $usedTcpPorts | % { $tcpRangesArray += [pscustomobject]@{P1 = $_; P2 = $_} }
-     $tcpRangesArray = ($tcpRangesArray | Sort-Object { $_.P1 })
+    # Extract the used TCP ports from the external interface
+    $usedTcpPorts  = (Get-NetTCPConnection -LocalAddress $hostIP -ErrorAction Ignore).LocalPort
+    $usedTcpPorts | % { $tcpRangesArray += [pscustomobject]@{P1 = $_; P2 = $_} }
+
+    # Extract the used TCP ports from the 0.0.0.0 interface
+    $usedTcpGlobalPorts = (Get-NetTCPConnection -LocalAddress "0.0.0.0" -ErrorAction Ignore).LocalPort
+    $usedTcpGlobalPorts | % { $tcpRangesArray += [pscustomobject]@{P1 = $_; P2 = $_} }
+    # Sort the list and remove duplicates
+    $tcpRangesArray = ($tcpRangesArray | Sort-Object { $_.P1 } -Unique)
+
+    $tcpRangesList = New-Object System.Collections.ArrayList($null)
+    $tcpRangesList.AddRange($tcpRangesArray)
+
+    # Remove overlapping ranges
+    for ($i = $tcpRangesList.P1.Length - 2; $i -gt 0 ; $i--) { 
+        if ($tcpRangesList[$i].P2 -gt $tcpRangesList[$i+1].P1 ) { 
+            Write-Host "Removing $($tcpRangesList[$i+1])"
+            $tcpRangesList.Remove($tcpRangesList[$i+1])
+            $i++
+        } 
+    }
 
     # Remove the non-ephemeral port reservations from the list
-    $filteredTcpRangeArray = $tcpRangesArray | ? { $_.P1 -ge $EphemeralPortStart }
+    $filteredTcpRangeArray = $tcpRangesList | ? { $_.P1 -ge $EphemeralPortStart }
     $filteredTcpRangeArray = $filteredTcpRangeArray | ? { $_.P2 -le $EphemeralPortEnd }
     
-    if ($filteredTcpRangeArray -eq $null)
-    {
+    if ($filteredTcpRangeArray -eq $null) {
         $freeRanges = @($EphemeralPortRange[1])
-    }
-    else
-    {
+    } else {
         $freeRanges = @()
         # The first free range goes from $EphemeralPortStart to the beginning of the first reserved range
         $freeRanges += ([Convert]::ToUInt32($filteredTcpRangeArray[0].P1) - $EphemeralPortStart)
@@ -107,12 +122,12 @@ function CountAvailableEphemeralPorts([string]$portocol = "TCP", [uint32]$portRa
         }
 
         # The last free range goes from the end of the last reserved range to $EphemeralPortEnd
-        $freeRanges += ($EphemeralPortEnd - [Convert]::ToUInt32($filteredTcpRangeArray[$filteredTcpRangeArray.length - 1].P2) - 1)
+        $freeRanges += ($EphemeralPortEnd - [Convert]::ToUInt32($filteredTcpRangeArray[$filteredTcpRangeArray.length - 1].P2))
     }
     
     # Count the number of available free ranges
     [uint32]$freeRangesCount = 0
-    ($freeRanges | % { $freeRangesCount += [UInt32]($_ / $portRangeSize) } )
+    ($freeRanges | % { $freeRangesCount += [Math]::Floor($_ / $portRangeSize) } )
 
     return $freeRangesCount
 }
@@ -125,12 +140,13 @@ if ($availableRangesFor64PortChunks -le 0) {
     echo "The ephemeral port range still has room for making up to $availableRangesFor64PortChunks allocations of 64 contiguous TCP ports" > reservedports.txt
 }
 
+& "$BaseDir\PortReservationTest.ps1" >> reservedports.txt
+
 netsh int ipv4 sh excludedportrange TCP > excludedportrange.txt
 netsh int ipv4 sh excludedportrange UDP >> excludedportrange.txt
 netsh int ipv4 sh dynamicportrange TCP > dynamicportrange.txt
 netsh int ipv4 sh dynamicportrange UDP >> dynamicportrange.txt
 netsh int ipv4 sh tcpconnections > tcpconnections.txt
-
 
 $ver = [System.Environment]::OSVersion
 $hotFix = Get-HotFix

--- a/Kubernetes/windows/debug/collectlogs.ps1
+++ b/Kubernetes/windows/debug/collectlogs.ps1
@@ -137,9 +137,14 @@ $availableRangesFor64PortChunks = CountAvailableEphemeralPorts
 if ($availableRangesFor64PortChunks -le 0) {
     echo "ERROR: Running out of ephemeral ports. The ephemeral ports range doesn't have enough resources to allow allocating 64 contiguous TCP ports." > reservedports.txt
 } else {
-    echo "The ephemeral port range still has room for making up to $availableRangesFor64PortChunks allocations of 64 contiguous TCP ports" > reservedports.txt
+    # There is unfortunately no exact way to calculate the ephemeral port ranges availability. 
+    # The calculation done in this script gives a very coarse estimate that may yield overly optimistic reasults on some systems.
+    # Use this data with caution.
+    echo "Rough estimation of the ephemeral port availability: up to $availableRangesFor64PortChunks allocations of 64 contiguous TCP ports may be possible" > reservedports.txt
 }
 
+# The following scripts attempts to reserve a few ranges of 64 ephemeral ports. 
+# Results produced by this test can accurately tell whether a system has room for reserving 64 contiguous port pools or not.
 & "$BaseDir\PortReservationTest.ps1" >> reservedports.txt
 
 netsh int ipv4 sh excludedportrange TCP > excludedportrange.txt

--- a/Kubernetes/windows/debug/portReservationTest.ps1
+++ b/Kubernetes/windows/debug/portReservationTest.ps1
@@ -137,5 +137,5 @@ if ($successCount -eq 10) {
 }
 
 if ([ws232.Win32Calls]::closesocket($socket) -ne 0) { throw "Failed to close the socket" }
-if ([ws232.Win32Calls]::WSACleanup() -ne 0) { throw "Failed to close the socket" }
+if ([ws232.Win32Calls]::WSACleanup() -ne 0) { throw "Failed to perform WSACleanup" }
 

--- a/Kubernetes/windows/debug/portReservationTest.ps1
+++ b/Kubernetes/windows/debug/portReservationTest.ps1
@@ -1,0 +1,141 @@
+
+$win32PInvoke = @'
+[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+public struct WSAData
+{
+    public Int16 version;
+    public Int16 highVersion;
+
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 257)]
+    public String description;
+
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 129)]
+    public String systemStatus;
+
+    public Int16 maxSockets;
+    public Int16 maxUdpDg;
+    public IntPtr vendorInfo;
+}
+
+[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+public struct INET_PORT_RANGE {
+    public UInt16 startPort;
+    public UInt16 numberOfPorts;
+}
+
+[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+public struct INET_PORT_RESERVATION_TOKEN{
+    UInt64 token;
+} 
+
+[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+public struct INET_PORT_RESERVATION_INSTANCE {
+    public INET_PORT_RANGE reservation;
+    public INET_PORT_RESERVATION_TOKEN token;
+} 
+
+public enum ADDRESS_FAMILIES : ushort
+{
+    AF_INET = 2,
+}
+
+public enum SOCKET_TYPE : ushort
+{
+    SOCK_NONE = 0,
+}
+
+public enum PROTOCOL : ushort
+{
+    IPPROTO_IP = 0,
+}
+
+public enum IOCTL_CODE : uint
+{
+    SIO_ACQUIRE_PORT_RESERVATION = 2550136932,
+}
+
+[DllImport("ws2_32.dll", CharSet = CharSet.Unicode, SetLastError=true)]
+public static extern Int32 WSAStartup(
+    Int16 wVersionRequested, 
+    out WSAData wsaData);
+
+[DllImport("ws2_32.dll",CharSet = CharSet.Unicode, SetLastError=true)]
+public static extern Int32 WSACleanup();
+
+[DllImport("ws2_32.dll", CharSet = CharSet.Unicode, SetLastError = true, CallingConvention = CallingConvention.StdCall)]
+public static extern IntPtr socket(
+    ADDRESS_FAMILIES af, 
+    SOCKET_TYPE socket_type, 
+    PROTOCOL protocol);
+
+[DllImport("ws2_32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+public static extern int closesocket(
+    IntPtr s);
+
+[DllImport("Ws2_32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+public static extern int WSAIoctl(
+    IntPtr s, 
+    IOCTL_CODE dwIoControlCode,
+    ref INET_PORT_RANGE lpvInBuffer, 
+    int cbInBuffer,
+    out INET_PORT_RESERVATION_INSTANCE lpvOutBuffer, 
+    int cbOutBuffer,
+    ref int lpcbBytesReturned,
+    IntPtr lpOverlapped, 
+    IntPtr lpCompletionRoutine);
+
+[DllImport("ws2_32.dll", CharSet = CharSet.Unicode, SetLastError=true)]
+public static extern UInt16 ntohs(
+    UInt16 netshort);
+
+[DllImport("ws2_32.dll", CharSet = CharSet.Unicode)]
+public static extern Int32 WSAGetLastError();
+'@
+
+Add-Type -MemberDefinition $win32PInvoke `
+    -Name Win32Calls -Namespace ws232 `
+    -Using System.Text
+
+[ws232.Win32Calls+WSAData] $WSAData = New-Object ws232.Win32Calls+WSAData
+if ([ws232.Win32Calls]::WSAStartup(0x0202, [Ref] $WSAData) -ne 0) { throw "WSAStartup failed" }
+
+[ws232.Win32Calls+ADDRESS_FAMILIES] $iFamily = [Int32][ws232.Win32Calls+ADDRESS_FAMILIES]::AF_INET;
+[ws232.Win32Calls+SOCKET_TYPE] $iType = [ws232.Win32Calls+SOCKET_TYPE]::SOCK_NONE;
+[ws232.Win32Calls+PROTOCOL] $iProtocol = [ws232.Win32Calls+PROTOCOL]::IPPROTO_IP;
+
+$socket = [ws232.Win32Calls]::socket($iFamily, $iType, $iProtocol)
+
+if ($socket -eq -1) { throw "Failed to open a socket" }
+
+[ws232.Win32Calls+INET_PORT_RANGE] $portRange = New-Object ws232.Win32Calls+INET_PORT_RANGE
+[ws232.Win32Calls+INET_PORT_RESERVATION_INSTANCE] $portRes = New-Object ws232.Win32Calls+INET_PORT_RESERVATION_INSTANCE
+[System.Int32] $bytesReturned = 0
+$portRange.numberOfPorts = 64
+
+$successCount = 0
+
+for ( $i = 0; $i -lt 10 ; $i++) {
+    if ([ws232.Win32Calls]::WSAIoctl(
+        $socket, 
+        [ws232.Win32Calls+IOCTL_CODE]::SIO_ACQUIRE_PORT_RESERVATION, 
+        [ref] $portRange, 
+        [System.Runtime.InteropServices.Marshal]::SizeOf($portRange),
+        [ref] $portRes,
+        [System.Runtime.InteropServices.Marshal]::SizeOf($portRes),
+        [ref] $bytesReturned,
+        [IntPtr]::Zero,
+        [IntPtr]::Zero) -eq 0) {
+
+        $successCount++
+    }
+}
+
+if ($successCount -eq 10) {
+    Write-Output "Successfully reserved 10 ranges of 64 ports"
+} else {
+    Write-Output "Couldn't reserve more than $($successCount) ranges of 64 ports"
+}
+
+if ([ws232.Win32Calls]::closesocket($socket) -ne 0) { throw "Failed to close the socket" }
+if ([ws232.Win32Calls]::WSACleanup() -ne 0) { throw "Failed to close the socket" }
+


### PR DESCRIPTION
Adding a tool to collectlogs.ps1 to further detect port allocation issues
- Adding the portReservationTest.ps1 tool to collectlogs.ps1
- Fixed the port estimation logic
- Fixed a spurious error on systems with no ports reserved

Tests run:
- ran collectlogs.ps1 locally