### PR TITLE
International Windows Versions compatibility

### DIFF
--- a/SDNExpress/Tools/SDNExplorer/CertHelpers.ps1
+++ b/SDNExpress/Tools/SDNExplorer/CertHelpers.ps1
@@ -102,7 +102,9 @@ function GivePermissionToNetworkService($targetCert)   {
     $targetCertPrivKey = $targetCert.PrivateKey 
     $privKeyCertFile = Get-Item -path "$ENV:ProgramData\Microsoft\Crypto\RSA\MachineKeys\*"  | where {$_.Name -eq $targetCertPrivKey.CspKeyContainerInfo.UniqueKeyContainerName} 
     $privKeyAcl = Get-Acl $privKeyCertFile
-    $permission = "NT AUTHORITY\NETWORK SERVICE","Read","Allow" 
+    $networkServiceSID = New-Object System.Security.Principal.SecurityIdentifier ("S-1-5-20")
+    $networkServiceAccount = ($networkServiceSID.Translate( [System.Security.Principal.NTAccount])).Value
+    $permission = $networkServiceAccount,"Read","Allow" 
     $accessRule = new-object System.Security.AccessControl.FileSystemAccessRule $permission 
     $privKeyAcl.AddAccessRule($accessRule) 
     Set-Acl $privKeyCertFile.FullName $privKeyAcl


### PR DESCRIPTION
Some adjustements to use SDNExpress on all Windows versions, and not only the english one.
This is done by using Well-known SID instead of hardcoded names (like "S-1-5-20" vs  "NT AUTHORITY\NETWORK SERVICE")

Since there is only two lines of code in four functions, I did not add a private function for them (should I ?)

Tested successfully on a french version of Windows Server 2019