### PR TITLE
Add tests for kubernetes 1.18 and kube-proxy daemonset

### DIFF
--- a/Kubernetes/windows/test_k8s_1.18/ValidateKubernetes.Pester.tests.ps1
+++ b/Kubernetes/windows/test_k8s_1.18/ValidateKubernetes.Pester.tests.ps1
@@ -1,0 +1,141 @@
+<#
+.DESCRIPTION
+    This script validates basic connectivity for Windows nodes in a Kubernetes cluster. 
+    Assumes the cluster has no other services/pods deployed besides kube-system
+#>
+
+param(
+    [Parameter()]
+    [string] $networkName = "vxlan0"
+)
+
+import-module "$PSScriptRoot\ValidateKubernetesHelper.psm1" 
+
+Describe 'Kubernetes Prerequisites' {
+    Context 'Checking Docker images' {
+        It "should have windowservercore image" {
+            docker images mcr.microsoft.com/windows/servercore:latest -q | Should Not BeNullOrEmpty
+        }
+    }
+
+    Context 'Checking Kubernetes Binaries are running' {
+        It 'kubelet.exe is running' {
+            get-process -Name 'kubelet' | Should be $true
+        }
+        It 'kube-proxy.exe is running' {
+            docker ps --filter name="kube-proxy-windows" --format "{{.Status}}" | Measure-Object -Line | Select-Object -ExpandProperty Lines | Should BeGreaterThan 1
+        }
+        It 'flanneld.exe is running' {
+            get-process -Name 'flanneld' | Should be $true
+        }
+    }
+}
+
+Describe 'Basic Connectivity Tests' {
+    Context 'Windows Connectivity' {
+        BeforeAll {
+            $Name = "win-webserver"
+            kubectl apply -f ./simpleweb.yml
+            kubectl scale deployment $Name --replicas=4
+            WaitForDeploymentCompletion -DeploymentName $Name
+            $workloadContainers = GetContainers -DeploymentName $Name
+            $localContainers = GetContainers -PodLocation Local -DeploymentName $Name
+            $remoteContainers = GetContainers -PodLocation Remote -DeploymentName $Name
+
+            $serviceVIP = (kubectl get services -o json | ConvertFrom-Json).items[1].spec.clusterIP
+            $nodePort = (kubectl get services -o json | ConvertFrom-Json).items[1].spec.ports.nodePort
+        }
+        AfterAll {
+            kubectl delete -f ./simpleweb.yml
+        }
+    
+        It 'should have more than 1 local container' {
+            $localContainers.count | Should BeGreaterThan 1
+        }
+        It 'should have at least 1 remote container' {
+            $remoteContainers.count | Should BeGreaterThan 0
+        }
+        It 'Pods should have correct IP' {
+            foreach ($container in $workloadContainers)
+            {
+                Write-Host "Checking $($container.Name) has IP address $($container.IPAddress)"
+                $container.IPAddress -eq (GetContainerIPv4Address -containerName $container.Name) | Should be $true
+            }
+        }
+        It 'Pods should have Internet connectivity' {
+            foreach ($container in $workloadContainers)
+            {
+		        Write-Host "Testing from $($container.Name) $($container.IPAddress)"
+                TestConnectivity -containerName $container.Name
+            }
+        }
+        It 'Pods should be able to resolve Service Name' {
+            foreach ($container in $workloadContainers)
+            {
+                Write-Host "Testing service $Name from ${container.Name} $($container.IPAddress)"
+                TestConnectivity -containerName $container.Name -remoteHost $Name
+            }
+        }
+        It 'Host should be able to reach Service Ip' {
+            foreach ($container in $workloadContainers)
+            {
+                Write-Host "Testing service VIP ${serviceVIP} from host"
+                TestConnectivity -fromHost -remoteHost $ServiceVip 
+            }
+        }
+        It 'Pods should be able to reach localhost' {
+            $managementIP = WaitForManagementIP -overlayNetwork $networkName
+            foreach ($container in $localContainers)
+            {
+                PingTest -containerName $container.Name -destination $managementIP
+            }
+        }
+        It 'Localhost should be able to reach local pod' {
+            foreach ($container in $localContainers)
+            {
+                PingTest -destination $container.IPAddress -fromHost
+            }
+        }
+        It 'Pod should be able to ping a local pod' {
+            foreach ($container1 in $localContainers)
+            {
+                foreach ($container2 in $localContainers)
+                {
+                    if ($container1.Name -ne $container2.Name) {
+                        PingTest -containerName $container1.Name -destination $container2.IPAddress
+                    }
+                }
+            }
+        } 
+        It 'Pod should be able to ping a remote pod' {
+            foreach ($container1 in $localContainers)
+            {
+                foreach ($container2 in $remoteContainers)
+                {
+                    PingTest -containerName $container1.Name -destination $container2.IPAddress
+                }
+            }
+        } 
+        It 'Remote host Should be able to access Node port' {
+            foreach ($container1 in $localContainers)
+            {
+                foreach ($container2 in $remoteContainers)
+                {
+                    TestConnectivity -remoteHost $container2.HostIP -port $nodePort -fromHost
+                }
+            }
+        }
+        '''
+        # LocalRoutedVip
+        It "Localhost Should be able to access Node port" {
+            foreach ($container1 in $localContainers)
+            {
+                foreach ($container2 in $remoteContainers)
+                {
+                    TestConnectivity -remoteHost $container2.HostIP -port $nodePort -fromHost
+                }
+            }
+        }
+        '''
+    }
+} 

--- a/Kubernetes/windows/test_k8s_1.18/ValidateKubernetesHelper.psm1
+++ b/Kubernetes/windows/test_k8s_1.18/ValidateKubernetesHelper.psm1
@@ -1,0 +1,161 @@
+function GetContainers
+{
+    param(
+        [ValidateSet("Local", "Remote")][string] $PodLocation,
+        $DeploymentName
+    )
+
+    $hostname = $(hostname)
+    $containers = @()
+
+    foreach ($pods in (kubectl get pods -o name | findstr $DeploymentName))
+    {
+        $c = ((kubectl get $pods -o json ) | ConvertFrom-Json)
+        $container = @{
+            Name = $c.metadata.name;
+            Service = $c.metadata.labels.app;
+            IPAddress = $c.status.podIP;
+            HostName = $c.spec.nodeName;
+            HostIP = $c.status.hostIP;
+            Status = $c.status.phase
+        }
+        if ($PodLocation -ieq "Local") {
+            if (!($container.HostName -ieq $hostname)) {
+                continue
+            }
+        }
+        if ($PodLocation -ieq "Remote") {
+            if ($container.HostName -ieq $hostname) {
+                continue
+            }
+        }
+        Write-Verbose "$($container | ConvertTo-Json)"
+        $containers += $container
+    }
+
+    return $containers;
+}
+
+function TestConnectivity()
+{
+    param(
+        [string] $containerName,
+        [string] $remoteHost = "www.google.com",
+        [string] $port = "80",
+        [switch] $fromHost
+    )
+    if ($fromHost.IsPresent)
+    {
+        Write-Verbose "Source [LocalHost] => [${remoteHost}:${port}]"
+    }
+    else
+    {
+        Write-Verbose "Source Container[$ContainerName] => [${remoteHost}:${port}]"
+    }
+    if ($fromHost) {
+        $status = curl "http://${remoteHost}:${port}" -UseBasicParsing -DisableKeepAlive
+        if ($status.StatusCode -eq "200") {
+            return
+        }
+        throw "TCP connection to ${remoteHost}:${port} failed from host. Result [$status]"
+    } else {
+        $status = kubectl exec $containerName -- powershell.exe curl "http://${remoteHost}:${port}" -UseBasicParsing -DisableKeepAlive
+    }
+
+    if ($status -match "200")
+    {
+        return
+    }
+
+    throw "TCP connection to ${remoteHost}:${port} failed from $containerName. Result [$status]"
+}
+
+function GetContainerIPv4Address()
+{
+    param(
+        [string] $containerName
+    )
+
+    $matches = (kubectl exec $containerName ipconfig | Out-String  | Select-String -Pattern '(?sm)(IPv4 Address).*?: (.*?)\r\n' -AllMatches).Matches
+    if ($matches -and $matches.Count -gt 0 -and $matches.Groups.Count -gt 0)
+    {
+        return ($matches.Groups | Select -Last 1).Value
+    }
+    return $null
+}
+
+function PingTest()
+{
+    param(
+        [string] $containerName,
+        [string] $destination,
+        [switch] $fromHost
+    )
+    
+    if ($fromHost) {
+        $returnStr =  ping $destination -n 4
+    } else {
+        $returnStr =  kubectl exec $containerName -- ping $destination -n 4
+    }
+
+    if ($returnStr -match "\(0% loss\)")
+    {     
+        return
+    }
+    
+    throw "PingTest failed on $containerName for destination $destination. Result [$returnStr]"
+}
+
+function WaitForManagementIp()
+{
+    param(
+        [string] $overlayNetwork = "vxlan0",
+	    [string] $bridgeNetwork = "cbr0"
+    )
+   
+    for ($i=0;$i -lt 60;$i++)
+    {
+        $hnsnetwork = Get-HnsNetwork | Where-Object {($_.Name -eq $overlayNetwork) -or ($_.Name -eq $bridgeNetwork)}
+        if (($hnsnetwork -ne $null) -and 
+            $hnsnetwork.ManagementIp -and 
+            (Get-NetIPAddress $hnsnetwork.ManagementIP -ErrorAction SilentlyContinue)
+            )
+        {
+            return $hnsnetwork.ManagementIp
+        }
+        sleep -Milliseconds 1000
+    }
+
+    throw "Host is not connected to internet"
+
+}
+
+function WaitForDeploymentCompletion($DeploymentName)
+{
+    $startTime = Get-Date
+    $waitTimeSeconds = 60
+
+    while ($true)
+    {
+        $timeElapsed = $(Get-Date) - $startTime
+        if ($($timeElapsed).TotalSeconds -ge $waitTimeSeconds)
+        {
+            throw "Fail to deploy ($DeploymentName)] in $waitTimeSeconds seconds"
+        }
+        $out = (kubectl get deployment $DeploymentName -o json  |ConvertFrom-Json)
+        if (!$out)
+        {
+            throw "Deployment $DeploymentName not found"
+        }
+        if ($out.status.availableReplicas -eq $out.status.replicas)
+        {
+            break;
+        }
+
+        Write-Host "Waiting for the deployment ($DeploymentName) to be complete. $($out.status)"
+        Start-Sleep 5
+    }
+
+
+}
+

--- a/Kubernetes/windows/test_k8s_1.18/simpleweb.yml
+++ b/Kubernetes/windows/test_k8s_1.18/simpleweb.yml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: win-webserver
+  labels:
+    app: win-webserver
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 80
+    targetPort: 80
+  selector:
+    app: win-webserver
+  type: NodePort
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: win-webserver
+  name: win-webserver
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: win-webserver
+  template:
+    metadata:
+      labels:
+        app: win-webserver
+      name: win-webserver
+    spec:
+     containers:
+      - name: windowswebserver
+        image: mcr.microsoft.com/windows/servercore:ltsc2019
+        command:
+        - powershell.exe
+        - -command
+        - "<#code used from https://gist.github.com/wagnerandrade/5424431#> ; $$listener = New-Object System.Net.HttpListener ; $$listener.Prefixes.Add('http://*:80/') ; $$listener.Start() ; $$callerCounts = @{} ; Write-Host('Listening at http://*:80/') ; while ($$listener.IsListening) { ;$$context = $$listener.GetContext() ;$$requestUrl = $$context.Request.Url ;$$clientIP = $$context.Request.RemoteEndPoint.Address ;$$response = $$context.Response ;Write-Host '' ;Write-Host('> {0}' -f $$requestUrl) ;  ;$$count = 1 ;$$k=$$callerCounts.Get_Item($$clientIP) ;if ($$k -ne $$null) { $$count += $$k } ;$$callerCounts.Set_Item($$clientIP, $$count) ;$$ip=(Get-NetAdapter | Get-NetIpAddress); $$header='<html><body><H1>Windows Container Web Server</H1>' ;$$callerCountsString='' ;$$callerCounts.Keys | % { $$callerCountsString+='<p>IP {0} callerCount {1} ' -f $$ip[1].IPAddress,$$callerCounts.Item($$_) } ;$$footer='</body></html>' ;$$content='{0}{1}{2}' -f $$header,$$callerCountsString,$$footer ;Write-Output $$content ;$$buffer = [System.Text.Encoding]::UTF8.GetBytes($$content) ;$$response.ContentLength64 = $$buffer.Length ;$$response.OutputStream.Write($$buffer, 0, $$buffer.Length) ;$$response.Close() ;$$responseStatus = $$response.StatusCode ;Write-Host('< {0}' -f $$responseStatus)  } ; "
+     nodeSelector:
+      kubernetes.io/os: windows
+ 


### PR DESCRIPTION
This PR copies the test for windows kubernetes CNI located at https://github.com/microsoft/SDN/tree/master/Kubernetes/windows/test and modifies the following things:

- The network name ("vxlan0" by default) is now a script parameter, so it can be configurated by the user
- Allows hostname of more than 15 characters length.
- Checks kube-proxy as a running daemonset, instead of a process.
- Updated spec file "simpleweb.yml" in k8s v1.18 format. 
