### PR TITLE
Remove superfluous container1 loop

### DIFF
--- a/Kubernetes/windows/test_k8s_1.18/ValidateKubernetes.Pester.tests.ps1
+++ b/Kubernetes/windows/test_k8s_1.18/ValidateKubernetes.Pester.tests.ps1
@@ -117,13 +117,10 @@ Describe 'Basic Connectivity Tests' {
             }
         } 
         It 'Remote host Should be able to access Node port' {
-            foreach ($container1 in $localContainers)
-            {
                 foreach ($container2 in $remoteContainers)
                 {
                     TestConnectivity -remoteHost $container2.HostIP -port $nodePort -fromHost
                 }
-            }
         }
         '''
         # LocalRoutedVip


### PR DESCRIPTION
The extra loop on `container1` is not necessary in the remote host to node port test. This test is only executed on remote containers. 