### PR TITLE
Collectlogs.ps1 calls hnsdiag to list out adapters

### DIFF
--- a/Kubernetes/windows/debug/collectlogs.ps1
+++ b/Kubernetes/windows/debug/collectlogs.ps1
@@ -58,6 +58,7 @@ $res = Get-Command hnsdiag.exe -ErrorAction SilentlyContinue
 if ($res)
 {
     hnsdiag list all -d > hnsdiag.txt
+    hnsdiag list adapters > hnsdiag.adapters.txt
 }
 hcsdiag list  > hcsdiag.txt
 


### PR DESCRIPTION
HNSDiag now lists adapters, so collectlogs is updated to collect that output.
If run on a machine without the new "list adapters" command, the output will be the usage text.
If run on a machine with an updated hnsdiag, the output will appear as follows:

```
////////////////////////ADAPTERS///////////////////////

Adapter : {0694B065-E10B-4A86-A34A-2C3F88B2909E}
    Name             : Ethernet
    Description      : Intel(R) Ethernet Connection I217-LM
    Index            : 5
    Luid             : 1689399632855040
    Type             : ethernet
    Compartment      : 1

Adapter : {A84CCFE6-4DD1-11EA-88E2-806E6F6E6963}
    Name             : Loopback Pseudo-Interface 1
    Description      : Software Loopback Interface 1
    Index            : 1
    Luid             : 6755399441055744
    Type             : loopback
    Compartment      : 1
```