### PR TITLE
Fix kubectl exec deprecated error

### DIFF
--- a/Kubernetes/windows/test_k8s_1.18/ValidateKubernetesHelper.psm1
+++ b/Kubernetes/windows/test_k8s_1.18/ValidateKubernetesHelper.psm1
@@ -76,7 +76,7 @@ function GetContainerIPv4Address()
         [string] $containerName
     )
 
-    $matches = (kubectl exec $containerName ipconfig | Out-String  | Select-String -Pattern '(?sm)(IPv4 Address).*?: (.*?)\r\n' -AllMatches).Matches
+    $matches = (kubectl exec $containerName -- ipconfig | Out-String  | Select-String -Pattern '(?sm)(IPv4 Address).*?: (.*?)\r\n' -AllMatches).Matches
     if ($matches -and $matches.Count -gt 0 -and $matches.Groups.Count -gt 0)
     {
         return ($matches.Groups | Select -Last 1).Value


### PR DESCRIPTION
At the windows kubernetes networking tests, this error is shown

kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl kubectl exec [POD] -- [COMMAND] instead. 

causing some problems in test pipelines.

This PR fixes it