### PR TITLE
Include all compartments in logging & get-port-counter

### DIFF
--- a/Kubernetes/windows/debug/collectlogs.ps1
+++ b/Kubernetes/windows/debug/collectlogs.ps1
@@ -46,6 +46,22 @@ Get-hnspolicylist | Convertto-json -Depth 20 > policy.txt
 vfpctrl.exe /list-vmswitch-port > ports.txt
 powershell $BaseDir\dumpVfpPolicies.ps1 -switchName $Network -outfile vfpOutput.txt
 
+# Loop through ports.txt file
+$ports = @()
+foreach($line in (Get-Content ports.txt)){
+    $nline = $line.Split(":")
+    if ($nline[0].contains('Port name'))
+    {
+        $ports += $nline[1]
+    }
+}
+
+# For each port, we want to call get-port-counter
+foreach($port in $ports)
+{
+    "Get-port-counter for port: $port" >> ports.txt
+    vfpctrl /port $port.trim() /get-port-counter >> ports.txt
+}
 ipconfig /allcompartments /all > ip.txt
 Get-NetIPAddress -IncludeAllCompartments >> ip.txt
 Get-NetIPInterface -IncludeAllCompartments >> ip.txt

--- a/Kubernetes/windows/debug/collectlogs.ps1
+++ b/Kubernetes/windows/debug/collectlogs.ps1
@@ -47,11 +47,16 @@ vfpctrl.exe /list-vmswitch-port > ports.txt
 powershell $BaseDir\dumpVfpPolicies.ps1 -switchName $Network -outfile vfpOutput.txt
 
 ipconfig /allcompartments /all > ip.txt
+Get-NetIPAddress -IncludeAllCompartments >> ip.txt
+Get-NetIPInterface -IncludeAllCompartments >> ip.txt
 route print > routes.txt
+Get-NetRoute -IncludeAllCompartments >> routes.txt
 netsh int ipv4 sh int > mtu.txt
 nvspinfo -a -i -h -D -p -d -m -q > nvspinfo.txt
 nmscrub -a -n -t > nmscrub.txt
 arp -a > arp.txt
+Get-NetNeighbor -IncludeAllCompartments >> arp.txt
+
 get-netadapter  | foreach {$ifindex=$_.IfIndex; $ifName=$_.Name; netsh int ipv4 sh int $ifindex | Out-File  -FilePath "${ifName}_int.txt" -Encoding ascii}
 
 $res = Get-Command hnsdiag.exe -ErrorAction SilentlyContinue


### PR DESCRIPTION
This change performs the following commands on all compartments: `Get-NetNeighbor`, `Get-NetRoute`, `Get-NetIPInterface`, `Get-NetIPAddress`. 
It also gets the port counter for all ports listed in ports.txt.