### PR TITLE
Update MultiNodeSampleConfig.psd1

### DIFF
--- a/SDNExpress/scripts/MultiNodeSampleConfig.psd1
+++ b/SDNExpress/scripts/MultiNodeSampleConfig.psd1
@@ -19,6 +19,7 @@
     #ManagmentSubnet, ManagementGateway, and ManagementDNS are not required if DHCP is configured for the management adapters below.
     ManagementSubnet     = '10.127.132.128/25'
     ManagementGateway    = '10.127.132.129'
+    #ManagementDNS property requires an array, so use @('10.127.130.7') if you want to specify only one DNS server address
     ManagementDNS        = @('10.127.130.7', '10.127.130.8')
     #Use 0, or comment out ManagementVLANID to configure the management adapter for untagged traffic 
     ManagementVLANID     = 7


### PR DESCRIPTION
Clarifying that ManagementDNS is an array, so a specific value format needs to be met in order to avoid execution error when just one DNS server IP address is needed (for example loadbalancer IP)