### PR TITLE
add HCN namespaces to logs and print v2 representation by default

### DIFF
--- a/Kubernetes/windows/hns.v2.psm1
+++ b/Kubernetes/windows/hns.v2.psm1
@@ -490,13 +490,13 @@ function Get-HnsGeneric
     $ids = ""
     $FilterString = ConvertTo-Json $Filter -depth 10
     $query = @{Filter = $FilterString }
-    if($Version -eq 2)
+    if($Version -eq 1)
     {
-        $query += @{SchemaVersion = @{ Major = 2; Minor = 0 }}
+        $query += @{SchemaVersion = @{ Major = 1; Minor = 0 }}
     }
     else
     {
-        $query += @{SchemaVersion = @{ Major = 1; Minor = 0 }}
+        $query += @{SchemaVersion = @{ Major = 2; Minor = 0 }}
     }
     if($Detailed.IsPresent)
     {


### PR DESCRIPTION
* Add argument to collectlogs.ps1 to pick HNS schema version to represent in logs
* Collectlogs.ps1 imports HNSv2.psm1 
*  Make HNSv2.psm1 use v2 representation by default
* Add HCN Namespaces logging to collectlogs.ps1