### PR TITLE
Fix logging mistake

### DIFF
--- a/SDNExpress/scripts/SDNExpressModule.psm1
+++ b/SDNExpress/scripts/SDNExpressModule.psm1
@@ -2227,7 +2227,7 @@ function Initialize-SDNExpressGateway {
         foreach ($res in $logicalsubnet.Properties.IpReservations) {
             $res = get-networkcontrollerIpReservation -connectionUri $uri @CredentialParam -NetworkId $FrontEndLogicalNetworkName -SubnetId $LogicalSubnet.resourceId
             if (![string]::IsNullOrEmpty($res.properties.reservedAddresses)) {
-                Write-LogInfo $OperationID "Appending IP $($res.properties.reservedAddresses)"
+                write-sdnexpresslog "Appending IP $($res.properties.reservedAddresses)"
                 $ips += $res.properties.reservedAddresses
             }
         }


### PR DESCRIPTION
When converting from SDNExpressLite (used in WAC) to SDN Express, I accidentally used the wrong logging statement - this throws an error than OperationId is undefined. Using write-sdnexpresslog matches other logging statements in this function