### PR TITLE
Enabling windows flags for performance improvement.

### DIFF
--- a/Kubernetes/windows/debug/enablewinflags/winserver2022.yaml
+++ b/Kubernetes/windows/debug/enablewinflags/winserver2022.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: enable-win-flags
+  labels:
+    app: enable-win-flags
+spec:
+  selector:
+    matchLabels:
+      name: enable-win-flags
+  template:
+    metadata:
+      labels:
+        name: enable-win-flags
+    spec:
+      securityContext:
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: "NT AUTHORITY\\SYSTEM"
+      hostNetwork: true
+      containers:
+      - name: enable-win-flags
+        image: mcr.microsoft.com/dotnet/framework/samples:aspnetapp
+        command:
+        - powershell.exe
+        - -command
+        - |
+            function EnableWinFlags {
+
+              $count = (reg query HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Policies\Microsoft\FeatureManagement\Overrides | sls "REG_DWORD" ).Count
+              $regKeySet = (reg query HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Policies\Microsoft\FeatureManagement\Overrides | sls "3444861581" ).Count
+
+              if(($count -ge 3) -and ($regKeySet -EQ 1)) {
+                Write-Host "Win flags are already enabled."
+                return
+              }
+
+              Write-Host "Adding registry key to enable the feature"
+              reg add HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Policies\Microsoft\FeatureManagement\Overrides /v 3444861581 /t REG_DWORD /d 1 /f
+              Start-Sleep -Seconds 2
+
+              Write-Host "Updating group policy"
+              gpupdate /force
+              Start-Sleep -Seconds 2
+
+              Write-Host "Running tasks to read the changes in step 1"
+              schtasks /run /tn "Microsoft\Windows\Flighting\FeatureConfig\ReconcileFeatures"
+              Start-Sleep -Seconds 2
+
+              Write-Host "Restarting computer for changes to take effect"
+              Start-Sleep -Seconds 5
+              Restart-Computer
+            }
+
+            EnableWinFlags
+
+            While($true) {
+              Write-Host "Ready to delete host process container."
+              Start-Sleep -Seconds 60
+            }
+
+        securityContext:
+          privileged: true
+      nodeSelector:
+        kubernetes.azure.com/os-sku: Windows2022
+        kubernetes.io/hostname: aksnpwin000000


### PR DESCRIPTION
Fixing bad performance when updating HNS policies for services in Windows nodes.

Changes needed in windows nodes.

1.	Add registry key to enable the feature:
       PS> reg add HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Policies\Microsoft\FeatureManagement\Overrides /v 3444861581 /t REG_DWORD /d 1 /f
2.	Update group policy:
        PS> gpupdate /force
3.	Run tasks to read the changes in #1:
        PS> schtasks /run /tn "Microsoft\Windows\Flighting\FeatureConfig\ReconcileFeatures"
4.	Restart computer for changes to take effect (one of the below)
a.	Via cmd: Shutdown -r -t 0
b.	Via PowerShell: Restart-Computer
