### PR TITLE
Backport sdnexpress from sdn tools to github repository

### DIFF
--- a/SDNExpress/scripts/MultiNodeSampleConfig.psd1
+++ b/SDNExpress/scripts/MultiNodeSampleConfig.psd1
@@ -31,6 +31,8 @@
 
     #RestName must contain the FQDN that will be assigned to the SDN REST floating IP.
     RestName             = 'sdn.contoso.com'
+    #When using the Rest IP Address, the RestName must be manually registered to this IP in DNS. This is the preferred way to deploy. 
+    RestIpAddress        = '10.127.130.105/31'
 
    NCs = @(
         #Optional parameters for each NC: 


### PR DESCRIPTION
Backported the following fixes/features:

- support to deploy using rest IP instead of rest name
- prefer certificates with nc oid in their ekus instead of server & client oids
- (preview) of deployment over a failover cluster