### PR TITLE
Update ProcessCertificate.ps1 for SCVMM2025

### DIFF
--- a/VMM/Templates/NC/EdgeDeployment.cr/ProcessCertificate.ps1
+++ b/VMM/Templates/NC/EdgeDeployment.cr/ProcessCertificate.ps1
@@ -128,7 +128,7 @@ $hostFqdn = [System.Net.Dns]::GetHostByName(($env:computerName)).HostName;
 $certSubjectName = "CN="+$hostFqdn;
 try
 {
-	[Reflection.Assembly]::LoadFile("C:\Program Files\Microsoft System Center\Virtual Machine Manager Guest Agent\bin\GuestAgent.Common.dll") | Out-Null
+	[Reflection.Assembly]::LoadFile("C:\Program Files\Microsoft System Center\Virtual Machine Manager Guest Agent 2025\bin\GuestAgent.Common.dll") | Out-Null
 	[Microsoft.VirtualManager.GuestAgent.Common.CertUtils]::CertificateChain($certSubjectName)
 }
 catch


### PR DESCRIPTION
SCVMM 2025 changed the path for the Guest Agent, which makes the GetCertChain function fail and cause a long loop when deploying SLB with CA-signed certificates. Updated the script to call the correct file path.